### PR TITLE
feat : 마이페이지 API 추가 (내 글/댓글 단 글/스크랩 목록)

### DIFF
--- a/src/main/java/com/inninglog/inninglog/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/inninglog/inninglog/domain/comment/repository/CommentRepository.java
@@ -2,8 +2,11 @@ package com.inninglog.inninglog.domain.comment.repository;
 
 import com.inninglog.inninglog.domain.comment.domain.Comment;
 import com.inninglog.inninglog.domain.contentType.ContentType;
+import com.inninglog.inninglog.domain.member.domain.Member;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -22,4 +25,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Modifying
     @Query("DELETE FROM Comment c WHERE c.contentType = :contentType AND c.targetId = :targetId")
     void deleteAllByContent(ContentType contentType, Long targetId);
+
+    // 마이페이지: 내가 댓글 단 게시글 ID 조회 (중복 제거, 최신순)
+    @Query("SELECT DISTINCT c.targetId FROM Comment c WHERE c.member = :member AND c.contentType = :contentType ORDER BY c.targetId DESC")
+    Slice<Long> findDistinctTargetIdsByMemberAndContentType(Member member, ContentType contentType, Pageable pageable);
 }

--- a/src/main/java/com/inninglog/inninglog/domain/comment/service/CommentGetService.java
+++ b/src/main/java/com/inninglog/inninglog/domain/comment/service/CommentGetService.java
@@ -16,6 +16,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -70,5 +72,11 @@ public class CommentGetService {
         }
 
         return roots;
+    }
+
+    //마이페이지: 내가 댓글 단 게시글 ID 조회
+    @Transactional(readOnly = true)
+    public Slice<Long> getCommentedPostIds(Member member, Pageable pageable) {
+        return commentRepository.findDistinctTargetIdsByMemberAndContentType(member, ContentType.POST, pageable);
     }
 }

--- a/src/main/java/com/inninglog/inninglog/domain/post/controller/PostGetController.java
+++ b/src/main/java/com/inninglog/inninglog/domain/post/controller/PostGetController.java
@@ -273,4 +273,215 @@ public class PostGetController {
 
         return ResponseEntity.ok(SuccessResponse.success(SuccessCode.OK, result));
     }
+
+    @Operation(
+            summary = "내가 쓴 글 목록 조회",
+            description = """
+                내가 작성한 게시글 목록을 조회합니다.
+
+                ✔ 최신순(postAt DESC)으로 정렬되어 반환됩니다.
+                ✔ page는 0부터 시작합니다. (0=첫 페이지)
+                ✔ size는 한 페이지에서 가져올 게시글 수를 의미합니다.
+                ✔ hasNext가 true이면 다음 페이지 요청이 가능합니다.
+                """,
+            tags = {"마이페이지"}
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "내가 쓴 글 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SliceResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "내가 쓴 글 목록", value = """
+                                        {
+                                          "code": "SUCCESS",
+                                          "message": "요청이 정상적으로 처리되었습니다.",
+                                          "data": {
+                                            "content": [
+                                              {
+                                                "postId": 45,
+                                                "teamShortCode": "LG",
+                                                "title": "오늘 경기 직관 후기",
+                                                "content": "오늘 잠실 가서 경기 봤는데 역전승해서 너무 좋았어요!",
+                                                "member": {
+                                                  "nickName": "볼빨간스트라스버그",
+                                                  "profile_url": "https://k.kakaocdn.net/.../img.jpg"
+                                                },
+                                                "likeCount": 12,
+                                                "scrapCount": 3,
+                                                "commentCount": 8,
+                                                "thumbImageUrl": "https://s3.amazonaws.com/.../thumb.jpg",
+                                                "imageCount": 3,
+                                                "postAt": "2025-06-03 18:30"
+                                              }
+                                            ],
+                                            "hasNext": true,
+                                            "page": 0,
+                                            "size": 10
+                                          }
+                                        }
+                                        """)
+                            }
+                    )
+            )
+    })
+    @GetMapping("/posts/my")
+    public ResponseEntity<SuccessResponse<SliceResponse<PostSummaryResDto>>> getMyPosts(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails user,
+
+            @Parameter(description = "조회할 페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+
+            @Parameter(description = "한 페이지당 게시글 개수", example = "10")
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        SliceResponse<PostSummaryResDto> result = postUsecase.getMyPosts(user.getMember(), pageable);
+
+        return ResponseEntity.ok(SuccessResponse.success(SuccessCode.OK, result));
+    }
+
+    @Operation(
+            summary = "내가 댓글 단 글 목록 조회",
+            description = """
+                내가 댓글을 작성한 게시글 목록을 조회합니다.
+
+                ✔ 최신 댓글을 단 게시글 순으로 정렬되어 반환됩니다.
+                ✔ 같은 게시글에 여러 댓글을 달아도 중복 없이 1번만 표시됩니다.
+                ✔ page는 0부터 시작합니다. (0=첫 페이지)
+                ✔ size는 한 페이지에서 가져올 게시글 수를 의미합니다.
+                ✔ hasNext가 true이면 다음 페이지 요청이 가능합니다.
+                """,
+            tags = {"마이페이지"}
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "내가 댓글 단 글 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SliceResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "내가 댓글 단 글 목록", value = """
+                                        {
+                                          "code": "SUCCESS",
+                                          "message": "요청이 정상적으로 처리되었습니다.",
+                                          "data": {
+                                            "content": [
+                                              {
+                                                "postId": 32,
+                                                "teamShortCode": "OB",
+                                                "title": "두산 팬들 모여라",
+                                                "content": "오늘 경기 어떻게 보셨나요?",
+                                                "member": {
+                                                  "nickName": "두산베어스팬",
+                                                  "profile_url": "https://k.kakaocdn.net/.../img.jpg"
+                                                },
+                                                "likeCount": 5,
+                                                "scrapCount": 1,
+                                                "commentCount": 15,
+                                                "thumbImageUrl": null,
+                                                "imageCount": 0,
+                                                "postAt": "2025-06-02 20:15"
+                                              }
+                                            ],
+                                            "hasNext": false,
+                                            "page": 0,
+                                            "size": 10
+                                          }
+                                        }
+                                        """)
+                            }
+                    )
+            )
+    })
+    @GetMapping("/posts/my/commented")
+    public ResponseEntity<SuccessResponse<SliceResponse<PostSummaryResDto>>> getMyCommentedPosts(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails user,
+
+            @Parameter(description = "조회할 페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+
+            @Parameter(description = "한 페이지당 게시글 개수", example = "10")
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        SliceResponse<PostSummaryResDto> result = postUsecase.getMyCommentedPosts(user.getMember(), pageable);
+
+        return ResponseEntity.ok(SuccessResponse.success(SuccessCode.OK, result));
+    }
+
+    @Operation(
+            summary = "내가 스크랩한 글 목록 조회",
+            description = """
+                내가 스크랩한 게시글 목록을 조회합니다.
+
+                ✔ 최근 스크랩한 순으로 정렬되어 반환됩니다.
+                ✔ page는 0부터 시작합니다. (0=첫 페이지)
+                ✔ size는 한 페이지에서 가져올 게시글 수를 의미합니다.
+                ✔ hasNext가 true이면 다음 페이지 요청이 가능합니다.
+                """,
+            tags = {"마이페이지"}
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "내가 스크랩한 글 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SliceResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "내가 스크랩한 글 목록", value = """
+                                        {
+                                          "code": "SUCCESS",
+                                          "message": "요청이 정상적으로 처리되었습니다.",
+                                          "data": {
+                                            "content": [
+                                              {
+                                                "postId": 58,
+                                                "teamShortCode": "LG",
+                                                "title": "잠실 좌석 추천",
+                                                "content": "1루 응원석 뷰가 정말 좋아요!",
+                                                "member": {
+                                                  "nickName": "야구덕후",
+                                                  "profile_url": "https://k.kakaocdn.net/.../img.jpg"
+                                                },
+                                                "likeCount": 28,
+                                                "scrapCount": 12,
+                                                "commentCount": 7,
+                                                "thumbImageUrl": "https://s3.amazonaws.com/.../view.jpg",
+                                                "imageCount": 5,
+                                                "postAt": "2025-06-01 14:00"
+                                              }
+                                            ],
+                                            "hasNext": true,
+                                            "page": 0,
+                                            "size": 10
+                                          }
+                                        }
+                                        """)
+                            }
+                    )
+            )
+    })
+    @GetMapping("/posts/my/scrapped")
+    public ResponseEntity<SuccessResponse<SliceResponse<PostSummaryResDto>>> getMyScrappedPosts(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails user,
+
+            @Parameter(description = "조회할 페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+
+            @Parameter(description = "한 페이지당 게시글 개수", example = "10")
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        SliceResponse<PostSummaryResDto> result = postUsecase.getMyScrappedPosts(user.getMember(), pageable);
+
+        return ResponseEntity.ok(SuccessResponse.success(SuccessCode.OK, result));
+    }
 }

--- a/src/main/java/com/inninglog/inninglog/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/inninglog/inninglog/domain/post/repository/PostRepository.java
@@ -1,6 +1,8 @@
 package com.inninglog.inninglog.domain.post.repository;
 
+import com.inninglog.inninglog.domain.member.domain.Member;
 import com.inninglog.inninglog.domain.post.domain.Post;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,4 +20,12 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     // 인기 게시글 조회: 좋아요 수 기준 (N+1 최적화)
     @Query("SELECT p FROM Post p JOIN FETCH p.member WHERE p.likeCount >= :minLikeCount ORDER BY p.postAt DESC")
     Slice<Post> findPopularPostsWithMember(long minLikeCount, Pageable pageable);
+
+    // 마이페이지: 내가 쓴 글 조회 (N+1 최적화)
+    @Query("SELECT p FROM Post p JOIN FETCH p.member WHERE p.member = :member ORDER BY p.postAt DESC")
+    Slice<Post> findByMemberWithMember(Member member, Pageable pageable);
+
+    // 마이페이지: ID 목록으로 게시글 조회 (N+1 최적화)
+    @Query("SELECT p FROM Post p JOIN FETCH p.member WHERE p.id IN :ids")
+    List<Post> findAllByIdInWithMember(List<Long> ids);
 }

--- a/src/main/java/com/inninglog/inninglog/domain/post/service/PostGetService.java
+++ b/src/main/java/com/inninglog/inninglog/domain/post/service/PostGetService.java
@@ -49,5 +49,17 @@ public class PostGetService {
     public Slice<Post> getPopularPosts(long minLikeCount, Pageable pageable) {
         return postRepository.findPopularPostsWithMember(minLikeCount, pageable);
     }
+
+    //마이페이지: 내가 쓴 글 조회
+    @Transactional(readOnly = true)
+    public Slice<Post> getMyPosts(Member member, Pageable pageable) {
+        return postRepository.findByMemberWithMember(member, pageable);
+    }
+
+    //마이페이지: ID 목록으로 게시글 조회 (순서 유지)
+    @Transactional(readOnly = true)
+    public List<Post> findAllByIds(List<Long> ids) {
+        return postRepository.findAllByIdInWithMember(ids);
+    }
 }
 

--- a/src/main/java/com/inninglog/inninglog/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/inninglog/inninglog/domain/scrap/repository/ScrapRepository.java
@@ -6,6 +6,8 @@ import com.inninglog.inninglog.domain.scrap.domain.Scrap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -24,4 +26,8 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     @Modifying
     @Query("DELETE FROM Scrap s WHERE s.contentType = :contentType AND s.targetId = :targetId")
     void deleteAllByContent(ContentType contentType, Long targetId);
+
+    // 마이페이지: 내가 스크랩한 게시글 ID 조회 (최신순)
+    @Query("SELECT s.targetId FROM Scrap s WHERE s.member = :member AND s.contentType = :contentType ORDER BY s.createdAt DESC")
+    Slice<Long> findTargetIdsByMemberAndContentType(Member member, ContentType contentType, Pageable pageable);
 }

--- a/src/main/java/com/inninglog/inninglog/domain/scrap/service/ScrapValidateService.java
+++ b/src/main/java/com/inninglog/inninglog/domain/scrap/service/ScrapValidateService.java
@@ -9,6 +9,8 @@ import com.inninglog.inninglog.global.exception.ErrorCode;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,5 +41,11 @@ public class ScrapValidateService {
     @Transactional(readOnly = true)
     public Set<Long> findScrapedTargetIds(ContentType contentType, List<Long> targetIds, Member member){
         return scrapRepository.findScrapedTargetIds(contentType, targetIds, member);
+    }
+
+    //마이페이지: 내가 스크랩한 게시글 ID 조회
+    @Transactional(readOnly = true)
+    public Slice<Long> getScrappedPostIds(Member member, Pageable pageable) {
+        return scrapRepository.findTargetIdsByMemberAndContentType(member, ContentType.POST, pageable);
     }
 }

--- a/src/main/java/com/inninglog/inninglog/global/dto/SliceResponse.java
+++ b/src/main/java/com/inninglog/inninglog/global/dto/SliceResponse.java
@@ -1,7 +1,9 @@
 package com.inninglog.inninglog.global.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Collections;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 @Schema(description = "Slice 기반 목록 응답")
@@ -24,6 +26,24 @@ public record SliceResponse<T>(
                 slice.hasNext(),
                 slice.getNumber(),
                 slice.getSize()
+        );
+    }
+
+    public static <T> SliceResponse<T> of(List<T> content, boolean hasNext, Pageable pageable) {
+        return new SliceResponse<>(
+                content,
+                hasNext,
+                pageable.getPageNumber(),
+                pageable.getPageSize()
+        );
+    }
+
+    public static <T> SliceResponse<T> empty(Pageable pageable) {
+        return new SliceResponse<>(
+                Collections.emptyList(),
+                false,
+                pageable.getPageNumber(),
+                pageable.getPageSize()
         );
     }
 }


### PR DESCRIPTION
- GET /community/posts/my : 내가 쓴 글 목록 조회
- GET /community/posts/my/commented : 내가 댓글 단 글 목록 조회
- GET /community/posts/my/scrapped : 내가 스크랩한 글 목록 조회

## 📄 작업 내용 요약


## 📎 Issue 번호
closed #번호

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **마이 페이지 기능** - 사용자가 작성한 게시물, 댓글 작성 게시물, 스크랩한 게시물을 페이지네이션 기능과 함께 별도로 조회할 수 있도록 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->