### PR TITLE
feat : 마이페이지 API 응답에 likedByMe, scrapedByMe 추가

### DIFF
--- a/src/main/java/com/inninglog/inninglog/domain/post/controller/PostGetController.java
+++ b/src/main/java/com/inninglog/inninglog/domain/post/controller/PostGetController.java
@@ -314,7 +314,9 @@ public class PostGetController {
                                                 "commentCount": 8,
                                                 "thumbImageUrl": "https://s3.amazonaws.com/.../thumb.jpg",
                                                 "imageCount": 3,
-                                                "postAt": "2025-06-03 18:30"
+                                                "postAt": "2025-06-03 18:30",
+                                                "likedByMe": true,
+                                                "scrapedByMe": false
                                               }
                                             ],
                                             "hasNext": true,
@@ -385,7 +387,9 @@ public class PostGetController {
                                                 "commentCount": 15,
                                                 "thumbImageUrl": null,
                                                 "imageCount": 0,
-                                                "postAt": "2025-06-02 20:15"
+                                                "postAt": "2025-06-02 20:15",
+                                                "likedByMe": false,
+                                                "scrapedByMe": true
                                               }
                                             ],
                                             "hasNext": false,
@@ -455,7 +459,9 @@ public class PostGetController {
                                                 "commentCount": 7,
                                                 "thumbImageUrl": "https://s3.amazonaws.com/.../view.jpg",
                                                 "imageCount": 5,
-                                                "postAt": "2025-06-01 14:00"
+                                                "postAt": "2025-06-01 14:00",
+                                                "likedByMe": true,
+                                                "scrapedByMe": true
                                               }
                                             ],
                                             "hasNext": true,

--- a/src/main/java/com/inninglog/inninglog/domain/post/dto/res/PostSummaryResDto.java
+++ b/src/main/java/com/inninglog/inninglog/domain/post/dto/res/PostSummaryResDto.java
@@ -39,12 +39,17 @@ public record PostSummaryResDto(
         Long imageCount,
 
         @Schema(description = "작성일", example = "2025-01-31 14:22")
-        String postAt
+        String postAt,
+
+        @Schema(description = "내가 좋아요 눌렀는지 여부 (마이페이지에서만 표시)", example = "true")
+        Boolean likedByMe,
+
+        @Schema(description = "내가 스크랩했는지 여부 (마이페이지에서만 표시)", example = "false")
+        Boolean scrapedByMe
 ) {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
     public static PostSummaryResDto of(Post post, MemberShortResDto member) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
-
         return new PostSummaryResDto(
                 post.getId(),
                 post.getTeamShortCode(),
@@ -56,7 +61,27 @@ public record PostSummaryResDto(
                 post.getCommentCount(),
                 post.getThumbnailUrl(),
                 post.getImageCount(),
-                post.getPostAt().format(formatter)
-                );
+                post.getPostAt().format(FORMATTER),
+                null,
+                null
+        );
+    }
+
+    public static PostSummaryResDto of(Post post, MemberShortResDto member, boolean likedByMe, boolean scrapedByMe) {
+        return new PostSummaryResDto(
+                post.getId(),
+                post.getTeamShortCode(),
+                post.getTitle(),
+                post.getContent(),
+                member,
+                post.getLikeCount(),
+                post.getScrapCount(),
+                post.getCommentCount(),
+                post.getThumbnailUrl(),
+                post.getImageCount(),
+                post.getPostAt().format(FORMATTER),
+                likedByMe,
+                scrapedByMe
+        );
     }
 }


### PR DESCRIPTION
- PostSummaryResDto에 좋아요/스크랩 여부 필드 추가
- N+1 최적화: 배치 조회로 좋아요/스크랩 여부 확인

## 📄 작업 내용 요약


## 📎 Issue 번호
closed #번호

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **새로운 기능**
  * 게시물 조회 응답에 두 개의 새로운 필드 추가: likedByMe와 scrapedByMe. API 응답을 통해 각 게시물에 대한 현재 사용자의 좋아요 여부와 스크랩 여부를 직접 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->