### PR TITLE
feat : 커뮤니티 검색 기능 추가 #109

### DIFF
--- a/src/main/java/com/inninglog/inninglog/domain/journal/controller/JournalController.java
+++ b/src/main/java/com/inninglog/inninglog/domain/journal/controller/JournalController.java
@@ -642,6 +642,46 @@ public class JournalController {
     }
 
     @Operation(
+            summary = "공개 직관 일지 검색",
+            description = """
+                키워드로 공개 직관 일지를 검색합니다.
+
+                📌 **검색 대상**: 후기 본문 (review_text)
+                📌 **정렬**: 작성순 (createdAt DESC)
+                📌 **페이지네이션**: Slice 기반 무한 스크롤
+
+                ✅ 예시: `/journals/search?keyword=역전승&page=0&size=10`
+                """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "검색 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = SliceResponse.class)
+            )
+    )
+    @GetMapping("/search")
+    public ResponseEntity<SuccessResponse<SliceResponse<JournalFeedResDto>>> searchJournals(
+            @Parameter(description = "검색 키워드", example = "역전승")
+            @RequestParam String keyword,
+
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+
+            @Parameter(description = "페이지 크기", example = "10")
+            @RequestParam(defaultValue = "10") int size,
+
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        SliceResponse<JournalFeedResDto> result = journalUsecase.searchPublicJournals(user.getMemberId(), keyword, pageable);
+
+        return ResponseEntity.ok(SuccessResponse.success(SuccessCode.OK, result));
+    }
+
+    @Operation(
             summary = "내가 쓴 직관 일지 목록 조회",
             description = """
                 내가 작성한 직관 일지 목록을 조회합니다.

--- a/src/main/java/com/inninglog/inninglog/domain/journal/repository/JournalRepository.java
+++ b/src/main/java/com/inninglog/inninglog/domain/journal/repository/JournalRepository.java
@@ -33,4 +33,8 @@ public interface JournalRepository extends JpaRepository<Journal, Long> {
     // 마이페이지: 내가 쓴 직관 일지 (Slice 기반)
     @Query("SELECT j FROM Journal j WHERE j.member = :member ORDER BY j.date DESC")
     Slice<Journal> findByMemberOrderByDateDesc(@Param("member") Member member, Pageable pageable);
+
+    // 커뮤니티 검색: 공개 일지 중 review_text 키워드 검색 (작성순)
+    @Query("SELECT j FROM Journal j JOIN FETCH j.member WHERE j.isPublic = true AND j.review_text LIKE %:keyword% ORDER BY j.createdAt DESC")
+    Slice<Journal> searchPublicJournals(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/inninglog/inninglog/domain/journal/service/JournalGetService.java
+++ b/src/main/java/com/inninglog/inninglog/domain/journal/service/JournalGetService.java
@@ -44,4 +44,10 @@ public class JournalGetService {
     public Slice<Journal> getMyJournals(Member member, Pageable pageable) {
         return journalRepository.findByMemberOrderByDateDesc(member, pageable);
     }
+
+    // 커뮤니티 검색: 공개 일지 키워드 검색
+    @Transactional(readOnly = true)
+    public Slice<Journal> searchPublicJournals(String keyword, Pageable pageable) {
+        return journalRepository.searchPublicJournals(keyword, pageable);
+    }
 }

--- a/src/main/java/com/inninglog/inninglog/domain/post/controller/PostGetController.java
+++ b/src/main/java/com/inninglog/inninglog/domain/post/controller/PostGetController.java
@@ -275,6 +275,48 @@ public class PostGetController {
     }
 
     @Operation(
+            summary = "게시글 검색",
+            description = """
+                키워드로 게시글을 검색합니다.
+
+                📌 **검색 대상**: 제목 (title) + 본문 (content)
+                📌 **정렬**: 최신순 (postAt DESC)
+                📌 **페이지네이션**: Slice 기반 무한 스크롤
+
+                ✅ 예시: `/community/posts/search?keyword=직관&page=0&size=10`
+                """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "게시글 검색 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SliceResponse.class)
+                    )
+            )
+    })
+    @GetMapping("/posts/search")
+    public ResponseEntity<SuccessResponse<SliceResponse<PostSummaryResDto>>> searchPosts(
+            @Parameter(description = "검색 키워드", example = "직관")
+            @RequestParam String keyword,
+
+            @Parameter(description = "조회할 페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+
+            @Parameter(description = "한 페이지당 게시글 개수", example = "10")
+            @RequestParam(defaultValue = "10") int size,
+
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        SliceResponse<PostSummaryResDto> result = postUsecase.searchPosts(user.getMember(), keyword, pageable);
+
+        return ResponseEntity.ok(SuccessResponse.success(SuccessCode.OK, result));
+    }
+
+    @Operation(
             summary = "내가 쓴 글 목록 조회",
             description = """
                 내가 작성한 게시글 목록을 조회합니다.

--- a/src/main/java/com/inninglog/inninglog/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/inninglog/inninglog/domain/post/repository/PostRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -28,4 +29,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     // 마이페이지: ID 목록으로 게시글 조회 (N+1 최적화)
     @Query("SELECT p FROM Post p JOIN FETCH p.member WHERE p.id IN :ids")
     List<Post> findAllByIdInWithMember(List<Long> ids);
+
+    // 커뮤니티 검색: 제목 또는 본문 키워드 검색 (최신순)
+    @Query("SELECT p FROM Post p JOIN FETCH p.member WHERE p.title LIKE %:keyword% OR p.content LIKE %:keyword% ORDER BY p.postAt DESC")
+    Slice<Post> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/inninglog/inninglog/domain/post/service/PostGetService.java
+++ b/src/main/java/com/inninglog/inninglog/domain/post/service/PostGetService.java
@@ -61,5 +61,11 @@ public class PostGetService {
     public List<Post> findAllByIds(List<Long> ids) {
         return postRepository.findAllByIdInWithMember(ids);
     }
+
+    //커뮤니티 검색: 키워드로 게시글 검색
+    @Transactional(readOnly = true)
+    public Slice<Post> searchByKeyword(String keyword, Pageable pageable) {
+        return postRepository.searchByKeyword(keyword, pageable);
+    }
 }
 


### PR DESCRIPTION
## Summary
- 직관 일지 검색 API 추가 (`GET /journals/search?keyword=`) - review_text 본문 검색, 작성순 정렬
- 게시글 검색 API 추가 (`GET /community/posts/search?keyword=`) - title + content 검색, 최신순 정렬
- 기존 목록 DTO 재사용, Slice 기반 무한 스크롤, 좋아요/스크랩 배치 조회 적용

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **저널 검색**: 공개된 저널을 키워드로 검색하여 관심사에 맞는 콘텐츠를 발견할 수 있습니다.
* **게시물 검색**: 커뮤니티 게시물을 제목과 내용에서 키워드로 검색할 수 있습니다.
* **무한 스크롤 지원**: 두 검색 기능 모두 무한 스크롤 방식의 페이지네이션으로 부드러운 탐색 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->