### PR TITLE
feat : 커뮤니티 검색에 teamShortCode 파라미터 추가 #113

### DIFF
--- a/src/main/java/com/inninglog/inninglog/domain/journal/controller/JournalController.java
+++ b/src/main/java/com/inninglog/inninglog/domain/journal/controller/JournalController.java
@@ -649,10 +649,12 @@ public class JournalController {
                 키워드로 공개 직관 일지를 검색합니다.
 
                 📌 **검색 대상**: 후기 본문 (review_text)
+                📌 **팀 필터링**: teamShortCode로 팀별 필터링 가능 (기본값: ALL = 전체)
                 📌 **정렬**: 작성순 (createdAt DESC)
                 📌 **페이지네이션**: Slice 기반 무한 스크롤
 
                 ✅ 예시: `/journals/search?keyword=역전승&page=0&size=10`
+                ✅ 팀 필터: `/journals/search?keyword=역전승&teamShortCode=LG&page=0&size=10`
                 """
     )
     @ApiResponse(
@@ -668,6 +670,9 @@ public class JournalController {
             @Parameter(description = "검색 키워드", example = "역전승")
             @RequestParam String keyword,
 
+            @Parameter(description = "팀 숏코드 (ALL: 전체, LG/OB 등: 팀별 필터)", example = "ALL")
+            @RequestParam(defaultValue = "ALL") String teamShortCode,
+
             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
             @RequestParam(defaultValue = "0") int page,
 
@@ -679,7 +684,7 @@ public class JournalController {
     ) {
         Pageable pageable = PageRequest.of(page, size);
         searchHistoryService.saveSearchKeyword(user.getMember(), keyword);
-        SliceResponse<JournalFeedResDto> result = journalUsecase.searchPublicJournals(user.getMemberId(), keyword, pageable);
+        SliceResponse<JournalFeedResDto> result = journalUsecase.searchPublicJournals(user.getMemberId(), keyword, teamShortCode, pageable);
 
         return ResponseEntity.ok(SuccessResponse.success(SuccessCode.OK, result));
     }

--- a/src/main/java/com/inninglog/inninglog/domain/journal/repository/JournalRepository.java
+++ b/src/main/java/com/inninglog/inninglog/domain/journal/repository/JournalRepository.java
@@ -37,4 +37,9 @@ public interface JournalRepository extends JpaRepository<Journal, Long> {
     // 커뮤니티 검색: 공개 일지 중 review_text 키워드 검색 (작성순)
     @Query("SELECT j FROM Journal j JOIN FETCH j.member WHERE j.isPublic = true AND j.review_text LIKE %:keyword% ORDER BY j.createdAt DESC")
     Slice<Journal> searchPublicJournals(@Param("keyword") String keyword, Pageable pageable);
+
+    // 커뮤니티 검색: 팀별 공개 일지 키워드 검색 (작성순)
+    @Query("SELECT j FROM Journal j JOIN FETCH j.member m JOIN FETCH m.team t " +
+           "WHERE j.isPublic = true AND t.shortCode = :teamShortCode AND j.review_text LIKE %:keyword% ORDER BY j.createdAt DESC")
+    Slice<Journal> searchPublicJournalsByTeam(@Param("keyword") String keyword, @Param("teamShortCode") String teamShortCode, Pageable pageable);
 }

--- a/src/main/java/com/inninglog/inninglog/domain/journal/service/JournalGetService.java
+++ b/src/main/java/com/inninglog/inninglog/domain/journal/service/JournalGetService.java
@@ -50,4 +50,10 @@ public class JournalGetService {
     public Slice<Journal> searchPublicJournals(String keyword, Pageable pageable) {
         return journalRepository.searchPublicJournals(keyword, pageable);
     }
+
+    // 커뮤니티 검색: 팀별 공개 일지 키워드 검색
+    @Transactional(readOnly = true)
+    public Slice<Journal> searchPublicJournalsByTeam(String keyword, String teamShortCode, Pageable pageable) {
+        return journalRepository.searchPublicJournalsByTeam(keyword, teamShortCode, pageable);
+    }
 }

--- a/src/main/java/com/inninglog/inninglog/domain/journal/usecase/JournalUsecase.java
+++ b/src/main/java/com/inninglog/inninglog/domain/journal/usecase/JournalUsecase.java
@@ -189,11 +189,16 @@ public class JournalUsecase {
         return SliceResponse.of(dtoSlice);
     }
 
-    // 커뮤니티 검색: 공개 일지 키워드 검색
+    // 커뮤니티 검색: 공개 일지 키워드 검색 (팀별 필터링 지원)
     @Transactional(readOnly = true)
-    public SliceResponse<JournalFeedResDto> searchPublicJournals(Long memberId, String keyword, Pageable pageable) {
+    public SliceResponse<JournalFeedResDto> searchPublicJournals(Long memberId, String keyword, String teamShortCode, Pageable pageable) {
         Member member = memberValidateService.findById(memberId);
-        Slice<Journal> journals = journalGetService.searchPublicJournals(keyword, pageable);
+        Slice<Journal> journals;
+        if ("ALL".equalsIgnoreCase(teamShortCode)) {
+            journals = journalGetService.searchPublicJournals(keyword, pageable);
+        } else {
+            journals = journalGetService.searchPublicJournalsByTeam(keyword, teamShortCode, pageable);
+        }
 
         List<Long> journalIds = journals.getContent().stream()
                 .map(Journal::getId)

--- a/src/main/java/com/inninglog/inninglog/domain/post/controller/PostGetController.java
+++ b/src/main/java/com/inninglog/inninglog/domain/post/controller/PostGetController.java
@@ -282,10 +282,12 @@ public class PostGetController {
                 키워드로 게시글을 검색합니다.
 
                 📌 **검색 대상**: 제목 (title) + 본문 (content)
+                📌 **팀 필터링**: teamShortCode로 팀별 필터링 가능 (기본값: ALL = 전체)
                 📌 **정렬**: 최신순 (postAt DESC)
                 📌 **페이지네이션**: Slice 기반 무한 스크롤
 
                 ✅ 예시: `/community/posts/search?keyword=직관&page=0&size=10`
+                ✅ 팀 필터: `/community/posts/search?keyword=직관&teamShortCode=LG&page=0&size=10`
                 """
     )
     @ApiResponses({
@@ -303,6 +305,9 @@ public class PostGetController {
             @Parameter(description = "검색 키워드", example = "직관")
             @RequestParam String keyword,
 
+            @Parameter(description = "팀 숏코드 (ALL: 전체, LG/OB 등: 팀별 필터)", example = "ALL")
+            @RequestParam(defaultValue = "ALL") String teamShortCode,
+
             @Parameter(description = "조회할 페이지 번호 (0부터 시작)", example = "0")
             @RequestParam(defaultValue = "0") int page,
 
@@ -314,7 +319,7 @@ public class PostGetController {
     ) {
         Pageable pageable = PageRequest.of(page, size);
         searchHistoryService.saveSearchKeyword(user.getMember(), keyword);
-        SliceResponse<PostSummaryResDto> result = postUsecase.searchPosts(user.getMember(), keyword, pageable);
+        SliceResponse<PostSummaryResDto> result = postUsecase.searchPosts(user.getMember(), keyword, teamShortCode, pageable);
 
         return ResponseEntity.ok(SuccessResponse.success(SuccessCode.OK, result));
     }

--- a/src/main/java/com/inninglog/inninglog/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/inninglog/inninglog/domain/post/repository/PostRepository.java
@@ -33,4 +33,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     // 커뮤니티 검색: 제목 또는 본문 키워드 검색 (최신순)
     @Query("SELECT p FROM Post p JOIN FETCH p.member WHERE p.title LIKE %:keyword% OR p.content LIKE %:keyword% ORDER BY p.postAt DESC")
     Slice<Post> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
+
+    // 커뮤니티 검색: 팀별 키워드 검색 (최신순)
+    @Query("SELECT p FROM Post p JOIN FETCH p.member WHERE p.teamShortCode = :teamShortCode AND (p.title LIKE %:keyword% OR p.content LIKE %:keyword%) ORDER BY p.postAt DESC")
+    Slice<Post> searchByKeywordAndTeam(@Param("keyword") String keyword, @Param("teamShortCode") String teamShortCode, Pageable pageable);
 }

--- a/src/main/java/com/inninglog/inninglog/domain/post/service/PostGetService.java
+++ b/src/main/java/com/inninglog/inninglog/domain/post/service/PostGetService.java
@@ -67,5 +67,11 @@ public class PostGetService {
     public Slice<Post> searchByKeyword(String keyword, Pageable pageable) {
         return postRepository.searchByKeyword(keyword, pageable);
     }
+
+    //커뮤니티 검색: 팀별 키워드로 게시글 검색
+    @Transactional(readOnly = true)
+    public Slice<Post> searchByKeywordAndTeam(String keyword, String teamShortCode, Pageable pageable) {
+        return postRepository.searchByKeywordAndTeam(keyword, teamShortCode, pageable);
+    }
 }
 

--- a/src/main/java/com/inninglog/inninglog/domain/post/service/PostUsecase.java
+++ b/src/main/java/com/inninglog/inninglog/domain/post/service/PostUsecase.java
@@ -164,10 +164,15 @@ public class PostUsecase {
         return CommunityHomeResDto.of(teamShortCode, popularPosts);
     }
 
-    //커뮤니티 검색: 키워드로 게시글 검색
+    //커뮤니티 검색: 키워드로 게시글 검색 (팀별 필터링 지원)
     @Transactional(readOnly = true)
-    public SliceResponse<PostSummaryResDto> searchPosts(Member member, String keyword, Pageable pageable) {
-        Slice<Post> posts = postGetService.searchByKeyword(keyword, pageable);
+    public SliceResponse<PostSummaryResDto> searchPosts(Member member, String keyword, String teamShortCode, Pageable pageable) {
+        Slice<Post> posts;
+        if ("ALL".equalsIgnoreCase(teamShortCode)) {
+            posts = postGetService.searchByKeyword(keyword, pageable);
+        } else {
+            posts = postGetService.searchByKeywordAndTeam(keyword, teamShortCode, pageable);
+        }
         List<Long> postIds = posts.stream().map(Post::getId).toList();
 
         Set<Long> likedPostIds = likeValidateService.findLikedTargetIds(ContentType.POST, postIds, member);


### PR DESCRIPTION
## Summary
- 커뮤니티 검색 API(`/community/posts/search`, `/journals/search`)에 `teamShortCode` 파라미터 추가
- `teamShortCode=ALL` (기본값): 전체 검색, 특정 팀코드 입력 시 해당 팀만 필터링
- `defaultValue = "ALL"`로 기존 클라이언트 하위 호환성 유지

## Test plan
- [ ] `GET /community/posts/search?keyword=직관` → 전체 검색 (기존 동작 유지)
- [ ] `GET /community/posts/search?keyword=직관&teamShortCode=LG` → LG 팀 게시글만 검색
- [ ] `GET /journals/search?keyword=역전승` → 전체 일지 검색 (기존 동작 유지)
- [ ] `GET /journals/search?keyword=역전승&teamShortCode=OB` → OB 팀 일지만 검색

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **팀별 검색 필터링** - 저널 및 게시글 검색 시 특정 팀으로 필터링할 수 있는 기능이 추가되었습니다. 기본값은 전체(ALL)이며, 팀 약칭을 지정하여 팀별 검색 결과를 조회할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->