### PR TITLE
feat : 직관 승률 DB 집계 쿼리로 개선 #115

### DIFF
--- a/src/main/java/com/inninglog/inninglog/domain/journal/controller/JournalController.java
+++ b/src/main/java/com/inninglog/inninglog/domain/journal/controller/JournalController.java
@@ -642,6 +642,46 @@ public class JournalController {
     }
 
     @Operation(
+            summary = "공개 직관 일지 검색",
+            description = """
+                키워드로 공개 직관 일지를 검색합니다.
+
+                📌 **검색 대상**: 후기 본문 (review_text)
+                📌 **정렬**: 작성순 (createdAt DESC)
+                📌 **페이지네이션**: Slice 기반 무한 스크롤
+
+                ✅ 예시: `/journals/search?keyword=역전승&page=0&size=10`
+                """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "검색 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = SliceResponse.class)
+            )
+    )
+    @GetMapping("/search")
+    public ResponseEntity<SuccessResponse<SliceResponse<JournalFeedResDto>>> searchJournals(
+            @Parameter(description = "검색 키워드", example = "역전승")
+            @RequestParam String keyword,
+
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+
+            @Parameter(description = "페이지 크기", example = "10")
+            @RequestParam(defaultValue = "10") int size,
+
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        SliceResponse<JournalFeedResDto> result = journalUsecase.searchPublicJournals(user.getMemberId(), keyword, pageable);
+
+        return ResponseEntity.ok(SuccessResponse.success(SuccessCode.OK, result));
+    }
+
+    @Operation(
             summary = "내가 쓴 직관 일지 목록 조회",
             description = """
                 내가 작성한 직관 일지 목록을 조회합니다.

--- a/src/main/java/com/inninglog/inninglog/domain/journal/controller/JournalController.java
+++ b/src/main/java/com/inninglog/inninglog/domain/journal/controller/JournalController.java
@@ -15,6 +15,7 @@ import com.inninglog.inninglog.domain.journal.dto.req.JourUpdateReqDto;
 
 import com.inninglog.inninglog.domain.journal.service.JournalService;
 import com.inninglog.inninglog.domain.kbo.dto.gameSchdule.GameSchResDto;
+import com.inninglog.inninglog.domain.searchHistory.service.SearchHistoryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 
@@ -47,6 +48,7 @@ public class JournalController {
 
     private final JournalService journalService;
     private final JournalUsecase journalUsecase;
+    private final SearchHistoryService searchHistoryService;
 
     //직관 일지 콘텐츠 업로드
     @Operation(
@@ -676,6 +678,7 @@ public class JournalController {
             @AuthenticationPrincipal CustomUserDetails user
     ) {
         Pageable pageable = PageRequest.of(page, size);
+        searchHistoryService.saveSearchKeyword(user.getMember(), keyword);
         SliceResponse<JournalFeedResDto> result = journalUsecase.searchPublicJournals(user.getMemberId(), keyword, pageable);
 
         return ResponseEntity.ok(SuccessResponse.success(SuccessCode.OK, result));

--- a/src/main/java/com/inninglog/inninglog/domain/journal/repository/JournalRepository.java
+++ b/src/main/java/com/inninglog/inninglog/domain/journal/repository/JournalRepository.java
@@ -33,4 +33,8 @@ public interface JournalRepository extends JpaRepository<Journal, Long> {
     // 마이페이지: 내가 쓴 직관 일지 (Slice 기반)
     @Query("SELECT j FROM Journal j WHERE j.member = :member ORDER BY j.date DESC")
     Slice<Journal> findByMemberOrderByDateDesc(@Param("member") Member member, Pageable pageable);
+
+    // 커뮤니티 검색: 공개 일지 중 review_text 키워드 검색 (작성순)
+    @Query("SELECT j FROM Journal j JOIN FETCH j.member WHERE j.isPublic = true AND j.review_text LIKE %:keyword% ORDER BY j.createdAt DESC")
+    Slice<Journal> searchPublicJournals(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/inninglog/inninglog/domain/journal/service/JournalGetService.java
+++ b/src/main/java/com/inninglog/inninglog/domain/journal/service/JournalGetService.java
@@ -44,4 +44,10 @@ public class JournalGetService {
     public Slice<Journal> getMyJournals(Member member, Pageable pageable) {
         return journalRepository.findByMemberOrderByDateDesc(member, pageable);
     }
+
+    // 커뮤니티 검색: 공개 일지 키워드 검색
+    @Transactional(readOnly = true)
+    public Slice<Journal> searchPublicJournals(String keyword, Pageable pageable) {
+        return journalRepository.searchPublicJournals(keyword, pageable);
+    }
 }

--- a/src/main/java/com/inninglog/inninglog/domain/kbo/dto/gameReport/WinningRateProjection.java
+++ b/src/main/java/com/inninglog/inninglog/domain/kbo/dto/gameReport/WinningRateProjection.java
@@ -1,0 +1,8 @@
+package com.inninglog.inninglog.domain.kbo.dto.gameReport;
+
+public interface WinningRateProjection {
+    int getTotalGames();
+    int getWinGames();
+    int getLoseGames();
+    int getDrawGames();
+}

--- a/src/main/java/com/inninglog/inninglog/domain/kbo/repository/VisitedGameRepository.java
+++ b/src/main/java/com/inninglog/inninglog/domain/kbo/repository/VisitedGameRepository.java
@@ -1,14 +1,25 @@
 package com.inninglog.inninglog.domain.kbo.repository;
 
 import com.inninglog.inninglog.domain.kbo.domain.VisitedGame;
+import com.inninglog.inninglog.domain.kbo.dto.gameReport.WinningRateProjection;
 import com.inninglog.inninglog.domain.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface VisitedGameRepository extends JpaRepository<VisitedGame, Long> {
 
     List<VisitedGame> findByMember(Member member);
+
+    @Query("SELECT COUNT(vg) AS totalGames, " +
+            "SUM(CASE WHEN vg.resultScore = 'WIN' THEN 1 ELSE 0 END) AS winGames, " +
+            "SUM(CASE WHEN vg.resultScore = 'LOSE' THEN 1 ELSE 0 END) AS loseGames, " +
+            "SUM(CASE WHEN vg.resultScore = 'DRAW' THEN 1 ELSE 0 END) AS drawGames " +
+            "FROM VisitedGame vg WHERE vg.member = :member")
+    Optional<WinningRateProjection> countWinningRate(@Param("member") Member member);
 }

--- a/src/main/java/com/inninglog/inninglog/domain/post/controller/PostGetController.java
+++ b/src/main/java/com/inninglog/inninglog/domain/post/controller/PostGetController.java
@@ -275,6 +275,48 @@ public class PostGetController {
     }
 
     @Operation(
+            summary = "게시글 검색",
+            description = """
+                키워드로 게시글을 검색합니다.
+
+                📌 **검색 대상**: 제목 (title) + 본문 (content)
+                📌 **정렬**: 최신순 (postAt DESC)
+                📌 **페이지네이션**: Slice 기반 무한 스크롤
+
+                ✅ 예시: `/community/posts/search?keyword=직관&page=0&size=10`
+                """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "게시글 검색 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SliceResponse.class)
+                    )
+            )
+    })
+    @GetMapping("/posts/search")
+    public ResponseEntity<SuccessResponse<SliceResponse<PostSummaryResDto>>> searchPosts(
+            @Parameter(description = "검색 키워드", example = "직관")
+            @RequestParam String keyword,
+
+            @Parameter(description = "조회할 페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+
+            @Parameter(description = "한 페이지당 게시글 개수", example = "10")
+            @RequestParam(defaultValue = "10") int size,
+
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        SliceResponse<PostSummaryResDto> result = postUsecase.searchPosts(user.getMember(), keyword, pageable);
+
+        return ResponseEntity.ok(SuccessResponse.success(SuccessCode.OK, result));
+    }
+
+    @Operation(
             summary = "내가 쓴 글 목록 조회",
             description = """
                 내가 작성한 게시글 목록을 조회합니다.

--- a/src/main/java/com/inninglog/inninglog/domain/post/controller/PostGetController.java
+++ b/src/main/java/com/inninglog/inninglog/domain/post/controller/PostGetController.java
@@ -5,6 +5,7 @@ import com.inninglog.inninglog.domain.post.dto.res.CommunityHomeResDto;
 import com.inninglog.inninglog.domain.post.dto.res.PostSingleResDto;
 import com.inninglog.inninglog.domain.post.dto.res.PostSummaryResDto;
 import com.inninglog.inninglog.domain.post.service.PostUsecase;
+import com.inninglog.inninglog.domain.searchHistory.service.SearchHistoryService;
 import com.inninglog.inninglog.global.auth.CustomUserDetails;
 import com.inninglog.inninglog.global.dto.SliceResponse;
 import com.inninglog.inninglog.global.response.SuccessCode;
@@ -35,6 +36,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "커뮤니티 - 게시글", description = "게시글 관련 API")
 public class PostGetController {
     private final PostUsecase postUsecase;
+    private final SearchHistoryService searchHistoryService;
 
     @Operation(
             summary = "커뮤니티 홈 조회",
@@ -311,6 +313,7 @@ public class PostGetController {
             @AuthenticationPrincipal CustomUserDetails user
     ) {
         Pageable pageable = PageRequest.of(page, size);
+        searchHistoryService.saveSearchKeyword(user.getMember(), keyword);
         SliceResponse<PostSummaryResDto> result = postUsecase.searchPosts(user.getMember(), keyword, pageable);
 
         return ResponseEntity.ok(SuccessResponse.success(SuccessCode.OK, result));

--- a/src/main/java/com/inninglog/inninglog/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/inninglog/inninglog/domain/post/repository/PostRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -28,4 +29,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     // 마이페이지: ID 목록으로 게시글 조회 (N+1 최적화)
     @Query("SELECT p FROM Post p JOIN FETCH p.member WHERE p.id IN :ids")
     List<Post> findAllByIdInWithMember(List<Long> ids);
+
+    // 커뮤니티 검색: 제목 또는 본문 키워드 검색 (최신순)
+    @Query("SELECT p FROM Post p JOIN FETCH p.member WHERE p.title LIKE %:keyword% OR p.content LIKE %:keyword% ORDER BY p.postAt DESC")
+    Slice<Post> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/inninglog/inninglog/domain/post/service/PostGetService.java
+++ b/src/main/java/com/inninglog/inninglog/domain/post/service/PostGetService.java
@@ -61,5 +61,11 @@ public class PostGetService {
     public List<Post> findAllByIds(List<Long> ids) {
         return postRepository.findAllByIdInWithMember(ids);
     }
+
+    //커뮤니티 검색: 키워드로 게시글 검색
+    @Transactional(readOnly = true)
+    public Slice<Post> searchByKeyword(String keyword, Pageable pageable) {
+        return postRepository.searchByKeyword(keyword, pageable);
+    }
 }
 

--- a/src/main/java/com/inninglog/inninglog/domain/searchHistory/controller/SearchHistoryController.java
+++ b/src/main/java/com/inninglog/inninglog/domain/searchHistory/controller/SearchHistoryController.java
@@ -1,0 +1,89 @@
+package com.inninglog.inninglog.domain.searchHistory.controller;
+
+import com.inninglog.inninglog.domain.searchHistory.dto.res.SearchHistoryResDto;
+import com.inninglog.inninglog.domain.searchHistory.service.SearchHistoryService;
+import com.inninglog.inninglog.global.auth.CustomUserDetails;
+import com.inninglog.inninglog.global.response.SuccessCode;
+import com.inninglog.inninglog.global.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/search")
+@Tag(name = "검색", description = "검색 관련 API")
+public class SearchHistoryController {
+
+    private final SearchHistoryService searchHistoryService;
+
+    @Operation(
+            summary = "최근 검색어 조회",
+            description = """
+                로그인한 유저의 최근 검색어를 최대 12개 조회합니다.
+
+                ✔ 최신순(createdAt DESC)으로 정렬
+                ✔ 동일 키워드 재검색 시 최신으로 갱신
+                """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "최근 검색어 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                {
+                                  "code": "SUCCESS",
+                                  "message": "요청이 정상적으로 처리되었습니다.",
+                                  "data": [
+                                    { "id": 15, "keyword": "역전승", "createdAt": "2026-02-26T14:30:00" },
+                                    { "id": 12, "keyword": "잠실", "createdAt": "2026-02-26T13:00:00" }
+                                  ]
+                                }
+                                """)
+                    )
+            )
+    })
+    @GetMapping("/history")
+    public ResponseEntity<SuccessResponse<List<SearchHistoryResDto>>> getRecentSearches(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        List<SearchHistoryResDto> result = searchHistoryService.getRecentSearches(user.getMember());
+        return ResponseEntity.ok(SuccessResponse.success(SuccessCode.OK, result));
+    }
+
+    @Operation(
+            summary = "검색어 삭제",
+            description = "특정 검색어를 삭제합니다. 본인의 검색어만 삭제 가능합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "검색어 삭제 성공")
+    })
+    @DeleteMapping("/history/{searchHistoryId}")
+    public ResponseEntity<SuccessResponse<Void>> deleteSearchHistory(
+            @Parameter(description = "검색 기록 ID", example = "1")
+            @PathVariable Long searchHistoryId,
+
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        searchHistoryService.deleteSearchHistory(searchHistoryId, user.getMember());
+        return ResponseEntity.ok(SuccessResponse.success(SuccessCode.OK, null));
+    }
+}

--- a/src/main/java/com/inninglog/inninglog/domain/searchHistory/domain/SearchHistory.java
+++ b/src/main/java/com/inninglog/inninglog/domain/searchHistory/domain/SearchHistory.java
@@ -1,0 +1,41 @@
+package com.inninglog.inninglog.domain.searchHistory.domain;
+
+import com.inninglog.inninglog.domain.member.domain.Member;
+import com.inninglog.inninglog.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SearchHistory extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String keyword;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    public static SearchHistory of(String keyword, Member member) {
+        return SearchHistory.builder()
+                .keyword(keyword)
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/com/inninglog/inninglog/domain/searchHistory/dto/res/SearchHistoryResDto.java
+++ b/src/main/java/com/inninglog/inninglog/domain/searchHistory/dto/res/SearchHistoryResDto.java
@@ -1,0 +1,18 @@
+package com.inninglog.inninglog.domain.searchHistory.dto.res;
+
+import com.inninglog.inninglog.domain.searchHistory.domain.SearchHistory;
+import java.time.LocalDateTime;
+
+public record SearchHistoryResDto(
+        Long id,
+        String keyword,
+        LocalDateTime createdAt
+) {
+    public static SearchHistoryResDto from(SearchHistory searchHistory) {
+        return new SearchHistoryResDto(
+                searchHistory.getId(),
+                searchHistory.getKeyword(),
+                searchHistory.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/inninglog/inninglog/domain/searchHistory/repository/SearchHistoryRepository.java
+++ b/src/main/java/com/inninglog/inninglog/domain/searchHistory/repository/SearchHistoryRepository.java
@@ -1,0 +1,21 @@
+package com.inninglog.inninglog.domain.searchHistory.repository;
+
+import com.inninglog.inninglog.domain.member.domain.Member;
+import com.inninglog.inninglog.domain.searchHistory.domain.SearchHistory;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SearchHistoryRepository extends JpaRepository<SearchHistory, Long> {
+
+    @Query("SELECT sh FROM SearchHistory sh WHERE sh.member = :member ORDER BY sh.createdAt DESC LIMIT 12")
+    List<SearchHistory> findRecentByMember(@Param("member") Member member);
+
+    Optional<SearchHistory> findByMemberAndKeyword(Member member, String keyword);
+
+    void deleteByIdAndMember(Long id, Member member);
+}

--- a/src/main/java/com/inninglog/inninglog/domain/searchHistory/service/SearchHistoryService.java
+++ b/src/main/java/com/inninglog/inninglog/domain/searchHistory/service/SearchHistoryService.java
@@ -1,0 +1,39 @@
+package com.inninglog.inninglog.domain.searchHistory.service;
+
+import com.inninglog.inninglog.domain.member.domain.Member;
+import com.inninglog.inninglog.domain.searchHistory.domain.SearchHistory;
+import com.inninglog.inninglog.domain.searchHistory.dto.res.SearchHistoryResDto;
+import com.inninglog.inninglog.domain.searchHistory.repository.SearchHistoryRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SearchHistoryService {
+
+    private final SearchHistoryRepository searchHistoryRepository;
+
+    @Transactional(readOnly = true)
+    public List<SearchHistoryResDto> getRecentSearches(Member member) {
+        return searchHistoryRepository.findRecentByMember(member).stream()
+                .map(SearchHistoryResDto::from)
+                .toList();
+    }
+
+    @Transactional
+    public void saveSearchKeyword(Member member, String keyword) {
+        // 동일 키워드가 있으면 삭제 후 재생성 (최신순 갱신)
+        Optional<SearchHistory> existing = searchHistoryRepository.findByMemberAndKeyword(member, keyword);
+        existing.ifPresent(searchHistoryRepository::delete);
+
+        searchHistoryRepository.save(SearchHistory.of(keyword, member));
+    }
+
+    @Transactional
+    public void deleteSearchHistory(Long id, Member member) {
+        searchHistoryRepository.deleteByIdAndMember(id, member);
+    }
+}


### PR DESCRIPTION
## Summary
- 직관 승률 계산 시 엔티티 전체 로딩(N개) → DB 집계 쿼리(COUNT + CASE WHEN)로 변경
- `WinningRateProjection` 인터페이스 추가
- `caculateWin`, `forHomeCaculateWin` 메서드 개선

## 변경 파일
- `WinningRateProjection.java` (신규) — DB 집계 결과 프로젝션 인터페이스
- `VisitedGameRepository.java` — `countWinningRate` 쿼리 추가
- `GameReportService.java` — 두 메서드가 집계 쿼리 사용하도록 변경

Closes #115