### PR TITLE
chore : dev 브랜치 CI/CD 자동 배포 파이프라인 구축 #118

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,9 @@
-name: CI/CD to Rented Server (Password SSH + ECR)
+name: CI/CD to Dev Server
 
 on:
   push:
     branches:
-      - deploy
+      - dev
 
 jobs:
   build-and-deploy:
@@ -14,16 +14,23 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: ${{ runner.os }}-gradle-
 
       - name: Build with Gradle
         run: ./gradlew build -x test
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -35,15 +42,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build & Push Multi-Arch Docker image
+      - name: Build & Push Docker image
         run: |
           docker buildx build \
-            --platform linux/amd64,linux/arm64 \
+            --platform linux/amd64 \
             -t ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:latest \
             --push \
             .
 
-      - name: Deploy via SSH with key
+      - name: Deploy via SSH
         uses: appleboy/ssh-action@v0.1.10
         with:
           host: ${{ secrets.SERVER_HOST }}
@@ -51,7 +58,8 @@ jobs:
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_KEY }}
           script: |
-            echo "✅ SSH 접속 성공!"
-            cd /home/ubuntu 
+            cd /home/ubuntu/InningLog_BE
+            aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin ${{ secrets.ECR_REGISTRY }}
             docker pull ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:latest
-            docker compose -f docker-compose.yml up -d --build
+            docker compose down
+            docker compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   inninglog-rest-server:
     image: 827762016815.dkr.ecr.ap-northeast-2.amazonaws.com/inninglog-dev:latest
-    container_name: inninlog-dev
+    container_name: inninglog-dev
     ports:
       - "8080:8080"
     env_file:


### PR DESCRIPTION
Closes #118

## 변경 내용

### `deploy.yml`
- 트리거 브랜치: `deploy` → `dev`
- Gradle 캐싱 추가 (빌드 속도 개선)
- 멀티 아키텍처 빌드 제거 (`linux/amd64`만)
- SSH 워킹 디렉토리: `/home/ubuntu` → `/home/ubuntu/InningLog_BE`
- 배포 스크립트: ECR 로그인 → pull → down → up -d
- 액션 버전 업데이트: `setup-java` v3→v4, `configure-aws-credentials` v2→v4

### `docker-compose.yml`
- 컨테이너명 오타 수정: `inninlog-dev` → `inninglog-dev`

## 필요한 GitHub Secrets 확인
- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
- `ECR_REGISTRY`, `ECR_REPOSITORY`
- `SERVER_HOST`, `SERVER_USER`, `SERVER_KEY`