### PR TITLE
chore : API 문서 자동 업데이트 파이프라인 구축 #120

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,3 +63,80 @@ jobs:
             docker pull ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:latest
             docker compose down
             docker compose up -d
+
+  update-api-docs:
+    needs: build-and-deploy
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Checkout main repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SERVER_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H ${{ secrets.SERVER_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Wait for server and fetch OpenAPI spec
+        run: |
+          SSH_CMD="ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no ${{ secrets.SERVER_USER }}@${{ secrets.SERVER_HOST }}"
+          for i in $(seq 1 30); do
+            if $SSH_CMD "curl -sf -u '${{ secrets.SWAGGER_NAME }}:${{ secrets.SWAGGER_PW }}' http://localhost:8080/v3/api-docs" > openapi.json 2>/dev/null; then
+              if [ -s openapi.json ]; then
+                echo "OpenAPI spec fetched successfully"
+                exit 0
+              fi
+            fi
+            echo "Waiting for server... ($i/30)"
+            sleep 5
+          done
+          echo "Failed to fetch OpenAPI spec after 150s"
+          exit 1
+
+      - name: Checkout docs repo
+        uses: actions/checkout@v4
+        with:
+          repository: InningLog/inninglog-api-docs
+          token: ${{ secrets.DOCS_REPO_TOKEN }}
+          path: docs-repo
+
+      - name: Run converter
+        run: node scripts/openapi-to-gitbook/src/index.js -i openapi.json -o docs-repo
+
+      - name: Create or update PR
+        working-directory: docs-repo
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No changes detected"
+            exit 0
+          fi
+
+          BRANCH="auto/api-docs-update"
+          git checkout -B "$BRANCH"
+          git add -A
+          git commit -m "docs : API 문서 자동 업데이트"
+          git push -f origin "$BRANCH"
+
+          PR_EXISTS=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -z "$PR_EXISTS" ]; then
+            gh pr create \
+              --title "docs : API 문서 자동 업데이트" \
+              --body "dev 서버 배포에 따른 API 문서 자동 업데이트입니다." \
+              --head "$BRANCH" \
+              --base main
+          else
+            echo "PR #$PR_EXISTS already exists, updated with force push"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_REPO_TOKEN }}

--- a/scripts/openapi-to-gitbook/package.json
+++ b/scripts/openapi-to-gitbook/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "openapi-to-gitbook",
+  "version": "1.0.0",
+  "description": "Convert OpenAPI spec to GitBook markdown for InningLog API docs",
+  "main": "src/index.js",
+  "scripts": {
+    "convert": "node src/index.js"
+  }
+}

--- a/scripts/openapi-to-gitbook/src/converter.js
+++ b/scripts/openapi-to-gitbook/src/converter.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { getDir } = require('./domainMapper');
+const { generateEndpointMarkdown, AUTO_MARKER } = require('./markdownGen');
+const { mergeSummary } = require('./summaryGen');
+
+function generateFileName(method, pathStr) {
+  const segments = pathStr
+    .replace(/^\/api\//, '')
+    .replace(/^\//, '')
+    .split('/')
+    .map(s => s.replace(/[{}]/g, ''))
+    .filter(Boolean);
+  return `${method}-${segments.join('-')}.md`;
+}
+
+function convert(spec, outputDir) {
+  const endpoints = [];
+  let filesWritten = 0;
+  let skipped = 0;
+  const domainSet = new Set();
+
+  const methods = ['get', 'post', 'put', 'patch', 'delete'];
+
+  for (const [pathStr, pathItem] of Object.entries(spec.paths || {})) {
+    for (const method of methods) {
+      const operation = pathItem[method];
+      if (!operation) continue;
+
+      const tag = operation.tags?.[0] || '기타';
+      const dir = getDir(tag);
+      domainSet.add(dir);
+
+      const fileName = generateFileName(method, pathStr);
+      const filePath = path.join(outputDir, dir, fileName);
+
+      // Skip manual files (no auto marker)
+      if (fs.existsSync(filePath)) {
+        const existing = fs.readFileSync(filePath, 'utf-8');
+        if (!existing.startsWith(AUTO_MARKER)) {
+          skipped++;
+          continue;
+        }
+      }
+
+      const markdown = generateEndpointMarkdown(method, pathStr, operation, spec);
+
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, markdown, 'utf-8');
+      filesWritten++;
+
+      endpoints.push({
+        tag,
+        dir,
+        fileName,
+        title: operation.summary || `${method.toUpperCase()} ${pathStr}`,
+      });
+    }
+  }
+
+  mergeSummary(outputDir, endpoints);
+
+  return { filesWritten, skipped, domains: domainSet.size };
+}
+
+module.exports = { convert };

--- a/scripts/openapi-to-gitbook/src/domainMapper.js
+++ b/scripts/openapi-to-gitbook/src/domainMapper.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const TAG_TO_DIR = {
+  '직관일지': 'journal',
+  '인증': 'auth',
+  '좌석후기': 'seat-view',
+  '커뮤니티': 'community',
+  '댓글': 'comment',
+  '좋아요': 'like',
+  '스크랩': 'scrap',
+  '회원': 'member',
+  'KBO': 'kbo',
+  '팀': 'team',
+  '경기장': 'stadium',
+  '이미지': 'image',
+  '카카오': 'kakao',
+  '게시글': 'post',
+};
+
+const DIR_TO_LABEL = {};
+for (const [label, dir] of Object.entries(TAG_TO_DIR)) {
+  DIR_TO_LABEL[dir] = label;
+}
+
+function getDir(tagName) {
+  if (!tagName) return 'etc';
+  return TAG_TO_DIR[tagName] || tagName.toLowerCase().replace(/\s+/g, '-');
+}
+
+function getTagLabel(dirOrTag) {
+  return DIR_TO_LABEL[dirOrTag] || dirOrTag;
+}
+
+module.exports = { getDir, getTagLabel, TAG_TO_DIR };

--- a/scripts/openapi-to-gitbook/src/index.js
+++ b/scripts/openapi-to-gitbook/src/index.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { convert } = require('./converter');
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const opts = {};
+  for (let i = 0; i < args.length; i += 2) {
+    if (args[i] === '-i') opts.input = args[i + 1];
+    else if (args[i] === '-o') opts.output = args[i + 1];
+  }
+  return opts;
+}
+
+function main() {
+  const opts = parseArgs();
+  if (!opts.input || !opts.output) {
+    console.error('Usage: node src/index.js -i <openapi.json> -o <output-dir>');
+    process.exit(1);
+  }
+
+  const specPath = path.resolve(opts.input);
+  if (!fs.existsSync(specPath)) {
+    console.error(`Input file not found: ${specPath}`);
+    process.exit(1);
+  }
+
+  const spec = JSON.parse(fs.readFileSync(specPath, 'utf-8'));
+  const result = convert(spec, path.resolve(opts.output));
+
+  console.log(`Generated ${result.filesWritten} files in ${result.domains} domains`);
+  if (result.skipped > 0) {
+    console.log(`Skipped ${result.skipped} existing manual files`);
+  }
+}
+
+main();

--- a/scripts/openapi-to-gitbook/src/markdownGen.js
+++ b/scripts/openapi-to-gitbook/src/markdownGen.js
@@ -1,0 +1,266 @@
+'use strict';
+
+const AUTO_MARKER = '<!-- AUTO-GENERATED -->';
+
+function resolveRef(ref, spec) {
+  const parts = ref.replace('#/', '').split('/');
+  let result = spec;
+  for (const part of parts) {
+    result = result?.[part];
+    if (!result) return null;
+  }
+  return result;
+}
+
+function resolveSchema(schema, spec, depth) {
+  if (!schema || depth > 8) return schema;
+  if (schema.$ref) {
+    return resolveSchema(resolveRef(schema.$ref, spec), spec, depth + 1);
+  }
+  if (schema.allOf) {
+    const merged = { type: 'object', properties: {}, required: [] };
+    for (const sub of schema.allOf) {
+      const resolved = resolveSchema(sub, spec, depth + 1);
+      if (resolved?.properties) Object.assign(merged.properties, resolved.properties);
+      if (resolved?.required) merged.required.push(...resolved.required);
+    }
+    return merged;
+  }
+  return schema;
+}
+
+function getTypeString(schema, spec) {
+  if (!schema) return 'Object';
+
+  const resolved = resolveSchema(schema, spec, 0);
+  if (!resolved) return 'Object';
+
+  if (resolved.type === 'array') {
+    const items = resolveSchema(resolved.items, spec, 0);
+    return `${getTypeString(items, spec)}[]`;
+  }
+
+  if (resolved.type === 'string' && resolved.enum) {
+    return `String (${resolved.enum.join(', ')})`;
+  }
+
+  if (resolved.format === 'int64') return 'Long';
+  if (resolved.format === 'int32') return 'Integer';
+  if (resolved.format === 'date') return 'LocalDate';
+  if (resolved.format === 'date-time') return 'LocalDateTime';
+
+  const typeMap = {
+    string: 'String',
+    integer: 'Integer',
+    number: 'Number',
+    boolean: 'Boolean',
+    object: 'Object',
+  };
+
+  return typeMap[resolved.type] || resolved.type || 'Object';
+}
+
+function flattenProperties(schema, spec, prefix, depth) {
+  if (!schema || depth > 3) return [];
+
+  const resolved = resolveSchema(schema, spec, 0);
+  if (!resolved?.properties) return [];
+
+  const rows = [];
+  const required = new Set(resolved.required || []);
+
+  for (const [name, prop] of Object.entries(resolved.properties)) {
+    const fieldName = prefix ? `${prefix}.${name}` : name;
+    const resolvedProp = resolveSchema(prop, spec, 0);
+    const type = getTypeString(prop, spec);
+    const isRequired = required.has(name);
+    const description = escapePipe(resolvedProp?.description || '');
+    const example = resolvedProp?.example !== undefined
+      ? escapePipe(String(resolvedProp.example))
+      : '';
+
+    rows.push({ fieldName, type, isRequired, description, example });
+
+    if (resolvedProp?.type === 'object' && resolvedProp?.properties) {
+      rows.push(...flattenProperties(resolvedProp, spec, fieldName, depth + 1));
+    }
+
+    if (resolvedProp?.type === 'array' && resolvedProp?.items) {
+      const itemSchema = resolveSchema(resolvedProp.items, spec, 0);
+      if (itemSchema?.type === 'object' && itemSchema?.properties) {
+        rows.push(...flattenProperties(itemSchema, spec, `${fieldName}[]`, depth + 1));
+      }
+    }
+  }
+
+  return rows;
+}
+
+function escapePipe(str) {
+  return str.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+function isAuthRequired(operation, spec) {
+  if (operation.security !== undefined) {
+    return operation.security.length > 0;
+  }
+  return !!(spec.security && spec.security.length > 0);
+}
+
+function generateEndpointMarkdown(method, pathStr, operation, spec) {
+  const lines = [AUTO_MARKER, ''];
+  const upperMethod = method.toUpperCase();
+
+  // 제목
+  lines.push(`## ${operation.summary || `${upperMethod} ${pathStr}`}`, '');
+
+  // 개요
+  lines.push('### 개요', '');
+  if (operation.description) {
+    lines.push(operation.description.trim(), '');
+  } else {
+    lines.push(`${upperMethod} ${pathStr}`, '');
+  }
+
+  // 엔드포인트
+  lines.push('### 엔드포인트', '');
+  lines.push(`\`${upperMethod} ${pathStr}\``, '');
+
+  // 인증
+  const requiresAuth = isAuthRequired(operation, spec);
+  lines.push('### 인증', '');
+  lines.push(requiresAuth ? '🔒 JWT 인증 필요' : '🔓 인증 불필요', '');
+
+  // 요청 (Request)
+  lines.push('### 요청 (Request)', '');
+
+  // Headers
+  lines.push('#### Headers', '');
+  lines.push('| 헤더 | 값 | 필수 |');
+  lines.push('|------|------|------|');
+  if (requiresAuth) {
+    lines.push('| Authorization | Bearer {token} | ✅ |');
+  }
+  if (operation.requestBody) {
+    const contentType = operation.requestBody.content?.['multipart/form-data']
+      ? 'multipart/form-data'
+      : 'application/json';
+    lines.push(`| Content-Type | ${contentType} | ✅ |`);
+  }
+  lines.push('');
+
+  // Path Parameters
+  const pathParams = (operation.parameters || []).filter(p => p.in === 'path');
+  if (pathParams.length > 0) {
+    lines.push('#### Path Parameters', '');
+    lines.push('| 파라미터 | 타입 | 필수 | 설명 | 예시 |');
+    lines.push('|----------|------|------|------|------|');
+    for (const param of pathParams) {
+      const type = getTypeString(param.schema || {}, spec);
+      const req = param.required ? '✅' : '';
+      const desc = escapePipe(param.description || '');
+      const ex = param.example ?? param.schema?.example ?? '';
+      lines.push(`| ${param.name} | ${type} | ${req} | ${desc} | ${ex} |`);
+    }
+    lines.push('');
+  }
+
+  // Query Parameters
+  const queryParams = (operation.parameters || []).filter(p => p.in === 'query');
+  if (queryParams.length > 0) {
+    lines.push('#### Query Parameters', '');
+    lines.push('| 파라미터 | 타입 | 필수 | 설명 | 예시 |');
+    lines.push('|----------|------|------|------|------|');
+    for (const param of queryParams) {
+      const type = getTypeString(param.schema || {}, spec);
+      const req = param.required ? '✅' : '';
+      const desc = escapePipe(param.description || '');
+      const ex = param.example ?? param.schema?.example ?? '';
+      lines.push(`| ${param.name} | ${type} | ${req} | ${desc} | ${ex} |`);
+    }
+    lines.push('');
+  }
+
+  // Request Body
+  if (operation.requestBody) {
+    const content = operation.requestBody.content?.['application/json']
+      || operation.requestBody.content?.['multipart/form-data'];
+
+    if (content?.schema) {
+      const fields = flattenProperties(content.schema, spec, '', 0);
+      if (fields.length > 0) {
+        lines.push('#### Body', '');
+        lines.push('| 필드명 | 타입 | 필수 | 설명 | 예시 |');
+        lines.push('|--------|------|------|------|------|');
+        for (const f of fields) {
+          lines.push(`| ${f.fieldName} | ${f.type} | ${f.isRequired ? '✅' : ''} | ${f.description} | ${f.example} |`);
+        }
+        lines.push('');
+      }
+    }
+
+    // 요청 예시
+    const examples = content?.examples;
+    if (examples) {
+      const first = Object.values(examples)[0];
+      if (first?.value) {
+        lines.push('#### 요청 예시', '');
+        lines.push('```json');
+        lines.push(JSON.stringify(first.value, null, 2));
+        lines.push('```', '');
+      }
+    }
+  }
+
+  // 응답 (Response) - 2xx만
+  lines.push('### 응답 (Response)', '');
+
+  const responses = operation.responses || {};
+  const successCodes = Object.keys(responses).filter(c => c.startsWith('2'));
+  const errorCodes = Object.keys(responses).filter(c => !c.startsWith('2'));
+
+  for (const code of successCodes) {
+    const res = responses[code];
+    const resContent = res.content?.['application/json'];
+
+    lines.push(`#### ${code} ${escapePipe(res.description || '')}`, '');
+
+    if (resContent?.schema) {
+      const fields = flattenProperties(resContent.schema, spec, '', 0);
+      if (fields.length > 0) {
+        lines.push('| 필드명 | 타입 | 설명 |');
+        lines.push('|--------|------|------|');
+        for (const f of fields) {
+          lines.push(`| ${f.fieldName} | ${f.type} | ${f.description} |`);
+        }
+        lines.push('');
+      }
+    }
+
+    if (resContent?.examples) {
+      const first = Object.values(resContent.examples)[0];
+      if (first?.value) {
+        lines.push('#### 응답 예시', '');
+        lines.push('```json');
+        lines.push(JSON.stringify(first.value, null, 2));
+        lines.push('```', '');
+      }
+    }
+  }
+
+  // 실패 (Error) - 비-2xx
+  if (errorCodes.length > 0) {
+    lines.push('### 실패 (Error)', '');
+    lines.push('| 코드 | 설명 |');
+    lines.push('|------|------|');
+    for (const code of errorCodes) {
+      const desc = escapePipe(responses[code].description || '');
+      lines.push(`| ${code} | ${desc} |`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+module.exports = { generateEndpointMarkdown, AUTO_MARKER };

--- a/scripts/openapi-to-gitbook/src/summaryGen.js
+++ b/scripts/openapi-to-gitbook/src/summaryGen.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { getTagLabel } = require('./domainMapper');
+
+const START_MARKER = '<!-- AUTO-GENERATED-START -->';
+const END_MARKER = '<!-- AUTO-GENERATED-END -->';
+
+function buildAutoSection(endpoints) {
+  // Group by domain directory
+  const groups = {};
+  for (const ep of endpoints) {
+    if (!groups[ep.dir]) {
+      groups[ep.dir] = { label: ep.tag, items: [] };
+    }
+    groups[ep.dir].items.push(ep);
+  }
+
+  const lines = [START_MARKER, ''];
+
+  // Sort domains alphabetically for consistency
+  const sortedDirs = Object.keys(groups).sort();
+  for (const dir of sortedDirs) {
+    const group = groups[dir];
+    lines.push(`## ${group.label}`, '');
+    for (const item of group.items) {
+      lines.push(`* [${item.title}](${dir}/${item.fileName})`);
+    }
+    lines.push('');
+  }
+
+  lines.push(END_MARKER);
+  return lines.join('\n');
+}
+
+function mergeSummary(outputDir, endpoints) {
+  if (endpoints.length === 0) return;
+
+  const summaryPath = path.join(outputDir, 'SUMMARY.md');
+  const autoSection = buildAutoSection(endpoints);
+
+  if (!fs.existsSync(summaryPath)) {
+    // No existing SUMMARY.md — create one with auto section
+    const content = `# Table of contents\n\n* [소개](README.md)\n\n${autoSection}\n`;
+    fs.writeFileSync(summaryPath, content, 'utf-8');
+    return;
+  }
+
+  const existing = fs.readFileSync(summaryPath, 'utf-8');
+  const startIdx = existing.indexOf(START_MARKER);
+  const endIdx = existing.indexOf(END_MARKER);
+
+  let merged;
+  if (startIdx !== -1 && endIdx !== -1) {
+    // Replace existing auto section
+    const before = existing.substring(0, startIdx);
+    const after = existing.substring(endIdx + END_MARKER.length);
+    merged = before + autoSection + after;
+  } else {
+    // Append auto section at the end
+    merged = existing.trimEnd() + '\n\n' + autoSection + '\n';
+  }
+
+  fs.writeFileSync(summaryPath, merged, 'utf-8');
+}
+
+module.exports = { mergeSummary };


### PR DESCRIPTION
## Summary
- OpenAPI JSON → GitBook 마크다운 변환 스크립트 추가 (`scripts/openapi-to-gitbook/`)
- `deploy.yml`에 `update-api-docs` job 추가 (배포 후 자동 실행, `continue-on-error: true`)
- 수동 작성 파일 보존, SUMMARY.md 병합 지원

## 필요 Secrets 추가
- `SWAGGER_NAME` / `SWAGGER_PW` — API docs Basic Auth
- `DOCS_REPO_TOKEN` — `inninglog-api-docs` 레포 접근용 PAT

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 자동 API 문서 생성 및 업데이트 워크플로우 추가
  * OpenAPI 사양을 마크다운 문서로 자동 변환
  * API 문서 저장소에 자동으로 풀 리퀘스트 생성 및 업데이트

* **Chores**
  * 문서 생성 도구 및 CI/CD 파이프라인 구성

<!-- end of auto-generated comment: release notes by coderabbit.ai -->