### PR TITLE
feat : 직관일지 마이페이지 기능 추가 #124

### DIFF
--- a/src/main/java/com/inninglog/inninglog/domain/comment/service/CommentGetService.java
+++ b/src/main/java/com/inninglog/inninglog/domain/comment/service/CommentGetService.java
@@ -79,4 +79,10 @@ public class CommentGetService {
     public Slice<Long> getCommentedPostIds(Member member, Pageable pageable) {
         return commentRepository.findDistinctTargetIdsByMemberAndContentType(member, ContentType.POST, pageable);
     }
+
+    //마이페이지: 내가 댓글 단 콘텐츠 ID 조회 (범용)
+    @Transactional(readOnly = true)
+    public Slice<Long> getCommentedContentIds(Member member, ContentType contentType, Pageable pageable) {
+        return commentRepository.findDistinctTargetIdsByMemberAndContentType(member, contentType, pageable);
+    }
 }

--- a/src/main/java/com/inninglog/inninglog/domain/journal/controller/JournalController.java
+++ b/src/main/java/com/inninglog/inninglog/domain/journal/controller/JournalController.java
@@ -757,5 +757,161 @@ public class JournalController {
 
         return ResponseEntity.ok(SuccessResponse.success(SuccessCode.OK, result));
     }
+
+    @Operation(
+            summary = "내가 댓글 단 직관 일지 목록 조회",
+            description = """
+                내가 댓글을 작성한 직관 일지 목록을 조회합니다.
+
+                ✔ 최근 댓글 단 순으로 정렬되어 반환됩니다.
+                ✔ page는 0부터 시작합니다. (0=첫 페이지)
+                ✔ size는 한 페이지에서 가져올 일지 수를 의미합니다.
+                ✔ hasNext가 true이면 다음 페이지 요청이 가능합니다.
+                """,
+            tags = {"마이페이지"}
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "내가 댓글 단 직관 일지 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SliceResponse.class)
+                    )
+            )
+    })
+    @GetMapping("/my/commented")
+    public ResponseEntity<SuccessResponse<SliceResponse<JournalFeedResDto>>> getMyCommentedJournals(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails user,
+
+            @Parameter(description = "조회할 페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+
+            @Parameter(description = "한 페이지당 일지 개수", example = "10")
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        SliceResponse<JournalFeedResDto> result = journalUsecase.getMyCommentedJournals(user.getMemberId(), pageable);
+
+        return ResponseEntity.ok(SuccessResponse.success(SuccessCode.OK, result));
+    }
+
+    @Operation(
+            summary = "내가 스크랩한 직관 일지 목록 조회",
+            description = """
+                내가 스크랩한 직관 일지 목록을 조회합니다.
+
+                ✔ 최근 스크랩한 순으로 정렬되어 반환됩니다.
+                ✔ page는 0부터 시작합니다. (0=첫 페이지)
+                ✔ size는 한 페이지에서 가져올 일지 수를 의미합니다.
+                ✔ hasNext가 true이면 다음 페이지 요청이 가능합니다.
+                """,
+            tags = {"마이페이지"}
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "내가 스크랩한 직관 일지 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SliceResponse.class)
+                    )
+            )
+    })
+    @GetMapping("/my/scrapped")
+    public ResponseEntity<SuccessResponse<SliceResponse<JournalFeedResDto>>> getMyScrappedJournals(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails user,
+
+            @Parameter(description = "조회할 페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+
+            @Parameter(description = "한 페이지당 일지 개수", example = "10")
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        SliceResponse<JournalFeedResDto> result = journalUsecase.getMyScrappedJournals(user.getMemberId(), pageable);
+
+        return ResponseEntity.ok(SuccessResponse.success(SuccessCode.OK, result));
+    }
+
+    @Operation(
+            summary = "내가 좋아요 누른 직관 일지 목록 조회",
+            description = """
+                내가 좋아요를 누른 직관 일지 목록을 조회합니다.
+
+                ✔ 최근 좋아요 누른 순으로 정렬되어 반환됩니다.
+                ✔ page는 0부터 시작합니다. (0=첫 페이지)
+                ✔ size는 한 페이지에서 가져올 일지 수를 의미합니다.
+                ✔ hasNext가 true이면 다음 페이지 요청이 가능합니다.
+                """,
+            tags = {"마이페이지"}
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "내가 좋아요 누른 직관 일지 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SliceResponse.class)
+                    )
+            )
+    })
+    @GetMapping("/my/liked")
+    public ResponseEntity<SuccessResponse<SliceResponse<JournalFeedResDto>>> getMyLikedJournals(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails user,
+
+            @Parameter(description = "조회할 페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+
+            @Parameter(description = "한 페이지당 일지 개수", example = "10")
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        SliceResponse<JournalFeedResDto> result = journalUsecase.getMyLikedJournals(user.getMemberId(), pageable);
+
+        return ResponseEntity.ok(SuccessResponse.success(SuccessCode.OK, result));
+    }
+
+    @Operation(
+            summary = "인기 직관 일지 목록 조회",
+            description = """
+                좋아요 10개 이상인 공개 직관 일지 목록을 조회합니다.
+
+                ✔ 최신순(createdAt DESC)으로 정렬되어 반환됩니다.
+                ✔ page는 0부터 시작합니다. (0=첫 페이지)
+                ✔ size는 한 페이지에서 가져올 일지 수를 의미합니다.
+                ✔ hasNext가 true이면 다음 페이지 요청이 가능합니다.
+                """,
+            tags = {"마이페이지"}
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "인기 직관 일지 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SliceResponse.class)
+                    )
+            )
+    })
+    @GetMapping("/popular")
+    public ResponseEntity<SuccessResponse<SliceResponse<JournalFeedResDto>>> getPopularJournals(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails user,
+
+            @Parameter(description = "조회할 페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+
+            @Parameter(description = "한 페이지당 일지 개수", example = "10")
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        SliceResponse<JournalFeedResDto> result = journalUsecase.getPopularJournals(user.getMemberId(), pageable);
+
+        return ResponseEntity.ok(SuccessResponse.success(SuccessCode.OK, result));
+    }
 }
 

--- a/src/main/java/com/inninglog/inninglog/domain/journal/repository/JournalRepository.java
+++ b/src/main/java/com/inninglog/inninglog/domain/journal/repository/JournalRepository.java
@@ -19,6 +19,10 @@ public interface JournalRepository extends JpaRepository<Journal, Long> {
 
     List<Journal> findAllByMemberAndResultScore(Member member, ResultScore resultScore);
 
+    long countByMember(Member member);
+
+    long countByMemberAndResultScore(Member member, ResultScore resultScore);
+
     Page<Journal> findAllByMember(Member member, Pageable pageable);
 
     Page<Journal> findAllByMemberAndResultScore(Member member, ResultScore resultScore, Pageable pageable);

--- a/src/main/java/com/inninglog/inninglog/domain/journal/repository/JournalRepository.java
+++ b/src/main/java/com/inninglog/inninglog/domain/journal/repository/JournalRepository.java
@@ -42,4 +42,12 @@ public interface JournalRepository extends JpaRepository<Journal, Long> {
     @Query("SELECT j FROM Journal j JOIN FETCH j.member m JOIN FETCH m.team t " +
            "WHERE j.isPublic = true AND t.shortCode = :teamShortCode AND j.review_text LIKE %:keyword% ORDER BY j.createdAt DESC")
     Slice<Journal> searchPublicJournalsByTeam(@Param("keyword") String keyword, @Param("teamShortCode") String teamShortCode, Pageable pageable);
+
+    // 마이페이지: ID 목록으로 일지 조회 (N+1 최적화)
+    @Query("SELECT j FROM Journal j JOIN FETCH j.member WHERE j.id IN :ids")
+    List<Journal> findAllByIdInWithMember(@Param("ids") List<Long> ids);
+
+    // 인기 직관일지 조회: 좋아요 수 기준, 공개 일지만 (N+1 최적화)
+    @Query("SELECT j FROM Journal j JOIN FETCH j.member WHERE j.likeCount >= :minLikeCount AND j.isPublic = true ORDER BY j.createdAt DESC")
+    Slice<Journal> findPopularJournalsWithMember(@Param("minLikeCount") long minLikeCount, Pageable pageable);
 }

--- a/src/main/java/com/inninglog/inninglog/domain/journal/service/JournalGetService.java
+++ b/src/main/java/com/inninglog/inninglog/domain/journal/service/JournalGetService.java
@@ -5,6 +5,10 @@ import com.inninglog.inninglog.domain.journal.repository.JournalRepository;
 import com.inninglog.inninglog.domain.member.domain.Member;
 import com.inninglog.inninglog.global.exception.CustomException;
 import com.inninglog.inninglog.global.exception.ErrorCode;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -55,5 +59,17 @@ public class JournalGetService {
     @Transactional(readOnly = true)
     public Slice<Journal> searchPublicJournalsByTeam(String keyword, String teamShortCode, Pageable pageable) {
         return journalRepository.searchPublicJournalsByTeam(keyword, teamShortCode, pageable);
+    }
+
+    // 마이페이지: ID 목록으로 일지 조회 (순서 보존)
+    @Transactional(readOnly = true)
+    public List<Journal> findAllByIds(List<Long> ids) {
+        return journalRepository.findAllByIdInWithMember(ids);
+    }
+
+    // 인기 직관일지 조회 (좋아요 수 기준)
+    @Transactional(readOnly = true)
+    public Slice<Journal> getPopularJournals(long minLikeCount, Pageable pageable) {
+        return journalRepository.findPopularJournalsWithMember(minLikeCount, pageable);
     }
 }

--- a/src/main/java/com/inninglog/inninglog/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/inninglog/inninglog/domain/like/repository/LikeRepository.java
@@ -7,6 +7,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -26,4 +28,8 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     @Modifying
     @Query("DELETE FROM Like l WHERE l.contentType = :contentType AND l.targetId = :targetId")
     void deleteAllByContent(ContentType contentType, Long targetId);
+
+    // 마이페이지: 내가 좋아요 누른 콘텐츠 ID 조회 (최신순)
+    @Query("SELECT l.targetId FROM Like l WHERE l.member = :member AND l.contentType = :contentType ORDER BY l.createdAt DESC")
+    Slice<Long> findTargetIdsByMemberAndContentType(Member member, ContentType contentType, Pageable pageable);
 }

--- a/src/main/java/com/inninglog/inninglog/domain/like/service/LikeValidateService.java
+++ b/src/main/java/com/inninglog/inninglog/domain/like/service/LikeValidateService.java
@@ -11,6 +11,8 @@ import com.inninglog.inninglog.global.exception.CustomException;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,6 +39,12 @@ public class LikeValidateService {
     @Transactional(readOnly = true)
     public Set<Long> findLikedTargetIds(ContentType contentType, List<Long> targetIds, Member member){
         return likeRepository.findLikedTargetIds(contentType, targetIds, member);
+    }
+
+    //마이페이지: 내가 좋아요 누른 콘텐츠 ID 조회
+    @Transactional(readOnly = true)
+    public Slice<Long> getLikedContentIds(Member member, ContentType contentType, Pageable pageable) {
+        return likeRepository.findTargetIdsByMemberAndContentType(member, contentType, pageable);
     }
 
     //이미 좋아요 누른건지 확인

--- a/src/main/java/com/inninglog/inninglog/domain/member/controller/MemberGetController.java
+++ b/src/main/java/com/inninglog/inninglog/domain/member/controller/MemberGetController.java
@@ -1,6 +1,7 @@
 package com.inninglog.inninglog.domain.member.controller;
 
 import com.inninglog.inninglog.domain.member.dto.res.MemberTeamResDto;
+import com.inninglog.inninglog.domain.member.dto.res.MyPageProfileResDto;
 import com.inninglog.inninglog.domain.member.service.MemberGetService;
 import com.inninglog.inninglog.global.auth.CustomUserDetails;
 import com.inninglog.inninglog.global.response.SuccessCode;
@@ -52,6 +53,38 @@ public class MemberGetController {
             @AuthenticationPrincipal CustomUserDetails user
     ){
         MemberTeamResDto dto = memberGetService.getMemberTeam(user.getMemberId());
+        return ResponseEntity.ok(SuccessResponse.success(SuccessCode.OK, dto));
+    }
+
+    @Operation(
+            summary = "마이페이지 프로필 조회",
+            description = """
+                로그인한 사용자의 마이페이지 프로필 정보를 조회합니다.
+
+                - 닉네임, 프로필 이미지, 응원팀 정보를 반환합니다.
+                - 직관 통계(총 직관 수, 승리 수, 승률)를 포함합니다.
+                """,
+            tags = {"마이페이지"}
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "프로필 조회 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없음"
+            )
+    })
+    @GetMapping("/profile")
+    public ResponseEntity<SuccessResponse<MyPageProfileResDto>> getMyPageProfile(
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        MyPageProfileResDto dto = memberGetService.getMyPageProfile(user.getMemberId());
         return ResponseEntity.ok(SuccessResponse.success(SuccessCode.OK, dto));
     }
 }

--- a/src/main/java/com/inninglog/inninglog/domain/member/dto/res/MyPageProfileResDto.java
+++ b/src/main/java/com/inninglog/inninglog/domain/member/dto/res/MyPageProfileResDto.java
@@ -1,0 +1,25 @@
+package com.inninglog.inninglog.domain.member.dto.res;
+
+import com.inninglog.inninglog.domain.member.domain.Member;
+
+public record MyPageProfileResDto(
+        String nickname,
+        String profileUrl,
+        String teamShortCode,
+        long totalGameCount,
+        long winCount,
+        double winRate
+) {
+    public static MyPageProfileResDto from(Member member, long totalCount, long winCount) {
+        double rate = totalCount == 0 ? 0.0
+                : Math.round((double) winCount / totalCount * 1000) / 10.0;
+        return new MyPageProfileResDto(
+                member.getNickname(),
+                member.getProfile_url(),
+                member.getTeam() != null ? member.getTeam().getShortCode() : null,
+                totalCount,
+                winCount,
+                rate
+        );
+    }
+}

--- a/src/main/java/com/inninglog/inninglog/domain/member/service/MemberGetService.java
+++ b/src/main/java/com/inninglog/inninglog/domain/member/service/MemberGetService.java
@@ -1,8 +1,11 @@
 package com.inninglog.inninglog.domain.member.service;
 
+import com.inninglog.inninglog.domain.journal.domain.ResultScore;
+import com.inninglog.inninglog.domain.journal.repository.JournalRepository;
 import com.inninglog.inninglog.domain.member.domain.Member;
 import com.inninglog.inninglog.domain.member.dto.res.MemberShortResDto;
 import com.inninglog.inninglog.domain.member.dto.res.MemberTeamResDto;
+import com.inninglog.inninglog.domain.member.dto.res.MyPageProfileResDto;
 import com.inninglog.inninglog.domain.member.repository.MemberRepository;
 import com.inninglog.inninglog.global.exception.CustomException;
 import com.inninglog.inninglog.global.exception.ErrorCode;
@@ -14,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberGetService {
     private final MemberRepository memberRepository;
+    private final JournalRepository journalRepository;
 
     @Transactional(readOnly = true)
     public MemberShortResDto toMemberShortResDto(Member member) {
@@ -34,5 +38,16 @@ public class MemberGetService {
     public Member getMemberWithTeam(Long memberId) {
         return memberRepository.findByIdWithTeam(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public MyPageProfileResDto getMyPageProfile(Long memberId) {
+        Member member = memberRepository.findByIdWithTeam(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        long totalCount = journalRepository.countByMember(member);
+        long winCount = journalRepository.countByMemberAndResultScore(member, ResultScore.WIN);
+
+        return MyPageProfileResDto.from(member, totalCount, winCount);
     }
 }

--- a/src/main/java/com/inninglog/inninglog/domain/scrap/service/ScrapValidateService.java
+++ b/src/main/java/com/inninglog/inninglog/domain/scrap/service/ScrapValidateService.java
@@ -48,4 +48,10 @@ public class ScrapValidateService {
     public Slice<Long> getScrappedPostIds(Member member, Pageable pageable) {
         return scrapRepository.findTargetIdsByMemberAndContentType(member, ContentType.POST, pageable);
     }
+
+    //마이페이지: 내가 스크랩한 콘텐츠 ID 조회 (범용)
+    @Transactional(readOnly = true)
+    public Slice<Long> getScrappedContentIds(Member member, ContentType contentType, Pageable pageable) {
+        return scrapRepository.findTargetIdsByMemberAndContentType(member, contentType, pageable);
+    }
 }


### PR DESCRIPTION
## Summary
- 직관일지(Journal)에 마이페이지 기능 4가지 추가
  - `GET /journals/my/commented` - 내가 댓글 단 직관일지
  - `GET /journals/my/scrapped` - 스크랩한 직관일지
  - `GET /journals/my/liked` - 좋아요 누른 직관일지
  - `GET /journals/popular` - 인기 직관일지 (좋아요 10개 이상)
- Post 도메인의 기존 마이페이지 패턴을 동일하게 적용
- Like/Scrap/Comment Service에 ContentType 범용 메서드 추가로 코드 재사용

## 변경 파일 (8개, +301줄)
- **Repository**: LikeRepository, JournalRepository 쿼리 추가
- **Service**: LikeValidateService, CommentGetService, ScrapValidateService, JournalGetService 범용 메서드 추가
- **Usecase**: JournalUsecase에 4개 비즈니스 메서드 + toFeedPage N+1 최적화 헬퍼
- **Controller**: JournalController에 4개 GET 엔드포인트 + Swagger 문서

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 내가 댓글/스크랩/좋아요한 저널 목록 조회 추가
  * 인기 저널 조회 추가
  * 마이페이지 프로필(닉네임·프로필·팀·전적) 조회 API 추가

* **성능 개선**
  * 저널 조회 시 멤버 정보 선로딩 등으로 조회 성능 및 페이징 효율 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->