### PR TITLE
fix : Team 승률 null일 때 직관 리포트 NPE 수정 #126

### DIFF
--- a/src/main/java/com/inninglog/inninglog/domain/kbo/service/GameReportService.java
+++ b/src/main/java/com/inninglog/inninglog/domain/kbo/service/GameReportService.java
@@ -200,6 +200,7 @@ public class GameReportService {
         log.info("📌 [generateReport] memberId={}, team='{}' 직관 리포트 생성 완료",
                 memberId, team.getShortCode());
 
-        return GameReportResDto.from(member.getNickname(),winningRateResult, team.getWinRate(), rankingResult);
+        return GameReportResDto.from(member.getNickname(),winningRateResult,
+                team.getWinRate() != null ? team.getWinRate() : 0.0, rankingResult);
     }
 }


### PR DESCRIPTION
## Summary
- Team.getWinRate()가 null일 때 double 언박싱으로 인한 NullPointerException 수정
- null인 경우 0.0 기본값 처리

## Test plan
- [ ] Team의 winRate가 null인 상태에서 직관 리포트 API 호출 시 정상 응답 확인
- [ ] Team의 winRate가 정상값일 때 기존 동작 유지 확인

Closes #126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 경기 리포트에서 승률 데이터가 누락된 경우를 안정적으로 처리하도록 개선했습니다. 이제 승률 정보가 없을 때 0.0으로 표시되어 리포트 생성 시 안정성이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->