### PR TITLE
fix : 인기 직관일지 Swagger 태그 잘못 분류 수정 #129

### DIFF
--- a/src/main/java/com/inninglog/inninglog/domain/journal/controller/JournalController.java
+++ b/src/main/java/com/inninglog/inninglog/domain/journal/controller/JournalController.java
@@ -884,8 +884,7 @@ public class JournalController {
                 ✔ page는 0부터 시작합니다. (0=첫 페이지)
                 ✔ size는 한 페이지에서 가져올 일지 수를 의미합니다.
                 ✔ hasNext가 true이면 다음 페이지 요청이 가능합니다.
-                """,
-            tags = {"마이페이지"}
+                """
     )
     @ApiResponses({
             @ApiResponse(


### PR DESCRIPTION
## Summary
- 인기 직관일지 API에 `tags = {"마이페이지"}`가 잘못 달려있던 것을 제거
- 클래스 레벨 태그인 "직관일지"로 정상 분류되도록 수정

## Test plan
- [ ] Swagger UI에서 인기 직관일지 API가 "직관일지" 태그 아래에 표시되는지 확인
- [ ] "마이페이지" 태그에 인기 직관일지가 더 이상 표시되지 않는지 확인

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **유지보수**
  * API 문서화 정리 및 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->