### PR TITLE
feat : 좌석 최근 검색 기록 저장/조회 API 추가 #138

### DIFF
--- a/src/main/java/com/inninglog/inninglog/domain/seatView/controller/SeatSearchController.java
+++ b/src/main/java/com/inninglog/inninglog/domain/seatView/controller/SeatSearchController.java
@@ -4,7 +4,9 @@ import com.inninglog.inninglog.global.auth.CustomUserDetails;
 import com.inninglog.inninglog.global.pageable.SimplePageResponse;
 import com.inninglog.inninglog.global.response.SuccessCode;
 import com.inninglog.inninglog.global.response.SuccessResponse;
+import com.inninglog.inninglog.domain.seatView.dto.res.RecentSeatSearchRes;
 import com.inninglog.inninglog.domain.seatView.dto.res.SeatViewImageResult;
+import com.inninglog.inninglog.domain.seatView.service.RecentSeatSearchService;
 import com.inninglog.inninglog.domain.seatView.service.SeatSearchService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -23,6 +25,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/seatViews/normal")
 @RequiredArgsConstructor
@@ -30,6 +34,7 @@ import org.springframework.web.bind.annotation.*;
 public class SeatSearchController {
 
     private final SeatSearchService seatSearchService;
+    private final RecentSeatSearchService recentSeatSearchService;
 
     @Operation(
             summary = "일반 좌석 검색",
@@ -154,9 +159,13 @@ public class SeatSearchController {
     ) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
 
+        Long memberId = user.getMember().getId();
+
         Page<SeatViewImageResult> response = seatSearchService.searchSeats(
-                user.getMember().getId(), stadiumShortCode, section, seatRow, pageable
+                memberId, stadiumShortCode, section, seatRow, pageable
         );
+
+        recentSeatSearchService.saveRecentSearch(memberId, stadiumShortCode, section, seatRow);
 
         SuccessCode code = response.isEmpty() ? SuccessCode.SEATVIEW_EMPTY : SuccessCode.SEATVIEW_LIST_FETCHED;
 
@@ -170,5 +179,46 @@ public class SeatSearchController {
                 .build();
 
         return ResponseEntity.ok(SuccessResponse.success(code, simplePage));
+    }
+
+    @Operation(
+            summary = "최근 검색한 좌석 조회",
+            description = "구장별로 최근 검색한 좌석 목록을 최대 3개까지 반환합니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "최근 검색 좌석 조회 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = @ExampleObject(
+                            value = """
+                                    {
+                                      "code": "RECENT_SEAT_SEARCH_FETCHED",
+                                      "message": "최근 검색 좌석 조회 성공",
+                                      "data": [
+                                        { "stadiumShortCode": "JAM", "section": "13", "seatRow": "3" },
+                                        { "stadiumShortCode": "JAM", "section": "22", "seatRow": null }
+                                      ]
+                                    }
+                                    """
+                    )
+            )
+    )
+    @GetMapping("/recent")
+    public ResponseEntity<SuccessResponse<List<RecentSeatSearchRes>>> getRecentSearches(
+            @AuthenticationPrincipal CustomUserDetails user,
+
+            @Parameter(
+                    description = "구장 단축코드",
+                    required = true,
+                    example = "JAM"
+            )
+            @RequestParam String stadiumShortCode
+    ) {
+        List<RecentSeatSearchRes> result = recentSeatSearchService.getRecentSearches(
+                user.getMember().getId(), stadiumShortCode
+        );
+
+        return ResponseEntity.ok(SuccessResponse.success(SuccessCode.RECENT_SEAT_SEARCH_FETCHED, result));
     }
 }

--- a/src/main/java/com/inninglog/inninglog/domain/seatView/domain/RecentSeatSearch.java
+++ b/src/main/java/com/inninglog/inninglog/domain/seatView/domain/RecentSeatSearch.java
@@ -1,0 +1,38 @@
+package com.inninglog.inninglog.domain.seatView.domain;
+
+import com.inninglog.inninglog.domain.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class RecentSeatSearch {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private String stadiumShortCode;
+
+    @Column(nullable = false)
+    private String section;
+
+    private String seatRow;
+
+    @Column(nullable = false)
+    private LocalDateTime searchedAt;
+
+    public void updateSearchedAt() {
+        this.searchedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/inninglog/inninglog/domain/seatView/dto/res/RecentSeatSearchRes.java
+++ b/src/main/java/com/inninglog/inninglog/domain/seatView/dto/res/RecentSeatSearchRes.java
@@ -1,0 +1,26 @@
+package com.inninglog.inninglog.domain.seatView.dto.res;
+
+import com.inninglog.inninglog.domain.seatView.domain.RecentSeatSearch;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RecentSeatSearchRes {
+
+    private String stadiumShortCode;
+    private String section;
+    private String seatRow;
+
+    public static RecentSeatSearchRes from(RecentSeatSearch entity) {
+        return RecentSeatSearchRes.builder()
+                .stadiumShortCode(entity.getStadiumShortCode())
+                .section(entity.getSection())
+                .seatRow(entity.getSeatRow())
+                .build();
+    }
+}

--- a/src/main/java/com/inninglog/inninglog/domain/seatView/repository/RecentSeatSearchRepository.java
+++ b/src/main/java/com/inninglog/inninglog/domain/seatView/repository/RecentSeatSearchRepository.java
@@ -1,0 +1,21 @@
+package com.inninglog.inninglog.domain.seatView.repository;
+
+import com.inninglog.inninglog.domain.member.domain.Member;
+import com.inninglog.inninglog.domain.seatView.domain.RecentSeatSearch;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RecentSeatSearchRepository extends JpaRepository<RecentSeatSearch, Long> {
+
+    List<RecentSeatSearch> findByMemberAndStadiumShortCodeOrderBySearchedAtDesc(Member member, String stadiumShortCode);
+
+    Optional<RecentSeatSearch> findByMemberAndStadiumShortCodeAndSectionAndSeatRow(
+            Member member, String stadiumShortCode, String section, String seatRow);
+
+    long countByMemberAndStadiumShortCode(Member member, String stadiumShortCode);
+
+    Optional<RecentSeatSearch> findFirstByMemberAndStadiumShortCodeOrderBySearchedAtAsc(
+            Member member, String stadiumShortCode);
+}

--- a/src/main/java/com/inninglog/inninglog/domain/seatView/service/RecentSeatSearchService.java
+++ b/src/main/java/com/inninglog/inninglog/domain/seatView/service/RecentSeatSearchService.java
@@ -1,0 +1,76 @@
+package com.inninglog.inninglog.domain.seatView.service;
+
+import com.inninglog.inninglog.domain.member.domain.Member;
+import com.inninglog.inninglog.domain.member.repository.MemberRepository;
+import com.inninglog.inninglog.domain.seatView.domain.RecentSeatSearch;
+import com.inninglog.inninglog.domain.seatView.dto.res.RecentSeatSearchRes;
+import com.inninglog.inninglog.domain.seatView.repository.RecentSeatSearchRepository;
+import com.inninglog.inninglog.global.exception.CustomException;
+import com.inninglog.inninglog.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RecentSeatSearchService {
+
+    private static final int MAX_RECENT_SEARCHES = 3;
+
+    private final RecentSeatSearchRepository recentSeatSearchRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void saveRecentSearch(Long memberId, String stadiumShortCode, String section, String seatRow) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Optional<RecentSeatSearch> existing = recentSeatSearchRepository
+                .findByMemberAndStadiumShortCodeAndSectionAndSeatRow(member, stadiumShortCode, section, seatRow);
+
+        if (existing.isPresent()) {
+            existing.get().updateSearchedAt();
+            log.info("🔄 [saveRecentSearch] memberId={}, stadium={}, section={}, row={} 기존 검색 기록 갱신",
+                    memberId, stadiumShortCode, section, seatRow);
+            return;
+        }
+
+        if (recentSeatSearchRepository.countByMemberAndStadiumShortCode(member, stadiumShortCode) >= MAX_RECENT_SEARCHES) {
+            RecentSeatSearch oldest = recentSeatSearchRepository
+                    .findFirstByMemberAndStadiumShortCodeOrderBySearchedAtAsc(member, stadiumShortCode)
+                    .orElseThrow();
+            recentSeatSearchRepository.delete(oldest);
+            log.info("🗑️ [saveRecentSearch] memberId={}, 가장 오래된 검색 기록 삭제 id={}", memberId, oldest.getId());
+        }
+
+        RecentSeatSearch newSearch = RecentSeatSearch.builder()
+                .member(member)
+                .stadiumShortCode(stadiumShortCode)
+                .section(section)
+                .seatRow(seatRow)
+                .searchedAt(LocalDateTime.now())
+                .build();
+
+        recentSeatSearchRepository.save(newSearch);
+        log.info("✅ [saveRecentSearch] memberId={}, stadium={}, section={}, row={} 새 검색 기록 저장",
+                memberId, stadiumShortCode, section, seatRow);
+    }
+
+    @Transactional(readOnly = true)
+    public List<RecentSeatSearchRes> getRecentSearches(Long memberId, String stadiumShortCode) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        return recentSeatSearchRepository
+                .findByMemberAndStadiumShortCodeOrderBySearchedAtDesc(member, stadiumShortCode)
+                .stream()
+                .map(RecentSeatSearchRes::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/inninglog/inninglog/global/response/SuccessCode.java
+++ b/src/main/java/com/inninglog/inninglog/global/response/SuccessCode.java
@@ -20,7 +20,8 @@ public enum SuccessCode {
     JOURNAL_EMPTY("JOURNAL_EMPTY", HttpStatus.OK, "해당 조건에 해당하는 직관 일지가 없습니다."),
     SEATVIEW_LIST_FETCHED("SEATVIEW_LIST_FETCHED", HttpStatus.OK, "시야 사진 조회 성공"),
     SEATVIEW_EMPTY("SEAT_VIEW_EMPTY", HttpStatus.OK, "해당 조건에 해당하는 시야 사진이 없습니다."),
-    WITHDRAW_SUCCESS("WITHDRAW_SUCCESS", HttpStatus.OK, "회원 탈퇴가 완료되었습니다.");
+    WITHDRAW_SUCCESS("WITHDRAW_SUCCESS", HttpStatus.OK, "회원 탈퇴가 완료되었습니다."),
+    RECENT_SEAT_SEARCH_FETCHED("RECENT_SEAT_SEARCH_FETCHED", HttpStatus.OK, "최근 검색 좌석 조회 성공");
 
 
 


### PR DESCRIPTION
Closes #138

## 변경 내용
- `RecentSeatSearch` 엔티티 추가 (member, stadiumShortCode, section, seatRow, searchedAt)
- 좌석 검색(`GET /seatViews/normal/gallery`) 시 자동으로 최근 검색 기록 저장
- 중복 검색 시 `searchedAt` 갱신 (최신 순 유지)
- 구장별 3개 초과 시 가장 오래된 항목 자동 삭제
- `GET /seatViews/normal/recent?stadiumShortCode=XX` 조회 API 추가

## 신규 파일
- `RecentSeatSearch.java` — 엔티티
- `RecentSeatSearchRepository.java` — JPA 레포지토리
- `RecentSeatSearchService.java` — 저장/조회 비즈니스 로직
- `RecentSeatSearchRes.java` — 응답 DTO

## 수정 파일
- `SeatSearchController.java` — 검색 시 자동 저장 + 조회 API 추가
- `SuccessCode.java` — `RECENT_SEAT_SEARCH_FETCHED` 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 좌석 검색 시 최근 검색 기록이 자동으로 저장됩니다.
* 경기장별로 최근 검색한 좌석 정보(경기장, 섹션, 좌석 열)를 조회할 수 있습니다.
* 사용자당 경기장별로 최대 3개의 최근 검색 기록이 유지되며, 새 검색 시 가장 오래된 기록이 자동 제거됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->