### PR TITLE
feat : 직관일지 없이 좌석시야 독립 등록 지원 #142

### DIFF
--- a/src/main/java/com/inninglog/inninglog/domain/seatView/controller/SeatViewController.java
+++ b/src/main/java/com/inninglog/inninglog/domain/seatView/controller/SeatViewController.java
@@ -40,8 +40,10 @@ public class SeatViewController {
         업로드된 파일명을 'fileName' 필드에 포함하여 요청해야 합니다.
 
         ✅ 필수 입력 필드:
-        - `journalId`: 연결된 직관 일지 ID
         - `stadiumShortCode`, `section`, `seatRow`: 좌석 정보
+
+        📎 선택 입력 필드:
+        - `journalId`: 연결할 직관 일지 ID (없으면 일지와 무관하게 독립 등록)
         - `emotionTagCodes`: 감정 태그 코드 배열 (문자열 리스트)
         - `fileNames`: 업로드한 이미지 파일명 리스트 (최대 5장, 확장자 포함)
 

--- a/src/main/java/com/inninglog/inninglog/domain/seatView/dto/req/SeatCreateReqDto.java
+++ b/src/main/java/com/inninglog/inninglog/domain/seatView/dto/req/SeatCreateReqDto.java
@@ -15,7 +15,7 @@ import java.util.List;
 @Schema(description = "좌석 후기 등록 요청 DTO")
 public class SeatCreateReqDto {
 
-    @Schema(description = "매핑되는 직관 일지의 ID", example = "12")
+    @Schema(description = "매핑되는 직관 일지의 ID (선택, 없으면 독립 등록)", example = "12", nullable = true)
     private Long journalId;
 
     @Schema(description = "경기장 숏코드 (ex. JAMS, DAE)", example = "JAM")

--- a/src/main/java/com/inninglog/inninglog/domain/seatView/dto/res/SeatCreateResDto.java
+++ b/src/main/java/com/inninglog/inninglog/domain/seatView/dto/res/SeatCreateResDto.java
@@ -17,7 +17,7 @@ public class SeatCreateResDto {
 
     public static SeatCreateResDto from(SeatView seatView) {
         return SeatCreateResDto.builder()
-                .JournalId(seatView.getJournal().getId())
+                .JournalId(seatView.getJournal() != null ? seatView.getJournal().getId() : null)
                 .SeatViewId(seatView.getId())
                 .build();
     }

--- a/src/main/java/com/inninglog/inninglog/domain/seatView/service/SeatViewService.java
+++ b/src/main/java/com/inninglog/inninglog/domain/seatView/service/SeatViewService.java
@@ -55,15 +55,18 @@ public class SeatViewService {
                     return new CustomException(ErrorCode.USER_NOT_FOUND);
                 });
 
-        Journal journal = journalRepository.findById(dto.getJournalId())
-                .orElseThrow(() -> {
-                    log.warn("❌ [createSeatView] journalId={} 존재하지 않는 직관 일지 ID", dto.getJournalId());
-                    return new CustomException(ErrorCode.JOURNAL_NOT_FOUND);
-                });
+        Journal journal = null;
+        if (dto.getJournalId() != null) {
+            journal = journalRepository.findById(dto.getJournalId())
+                    .orElseThrow(() -> {
+                        log.warn("❌ [createSeatView] journalId={} 존재하지 않는 직관 일지 ID", dto.getJournalId());
+                        return new CustomException(ErrorCode.JOURNAL_NOT_FOUND);
+                    });
 
-        if (journal.getSeatView() != null) {
-            log.warn("⚠️ [createSeatView] journalId={} 이미 좌석 시야가 등록된 일지 ID", dto.getJournalId());
-            throw new CustomException(ErrorCode.SEATVIEW_ALREADY_EXISTS);
+            if (journal.getSeatView() != null) {
+                log.warn("⚠️ [createSeatView] journalId={} 이미 좌석 시야가 등록된 일지 ID", dto.getJournalId());
+                throw new CustomException(ErrorCode.SEATVIEW_ALREADY_EXISTS);
+            }
         }
 
         Stadium stadium = stadiumRepository.findByShortCode(dto.getStadiumShortCode())
@@ -73,7 +76,9 @@ public class SeatViewService {
                 });
 
         SeatView seatView = SeatView.from(dto, member, journal, stadium);
-        journal.setSeatView(seatView);
+        if (journal != null) {
+            journal.setSeatView(seatView);
+        }
         seatViewRepository.save(seatView);
 
         // ContentImage 테이블에 이미지 저장


### PR DESCRIPTION
Closes #142

## 변경 내용
- `journalId` 선택값으로 변경 (없으면 일지와 무관하게 독립 등록)
- `journalId` 있는 경우 기존과 동일하게 일지 연결 + 중복 등록 체크
- 응답 `JournalId`는 일지 없을 경우 `null` 반환

## 수정 파일
- `SeatViewService.java` — journalId null 분기 처리
- `SeatCreateResDto.java` — journal null 시 NPE 방지
- `SeatCreateReqDto.java` — journalId 선택값 Swagger 명시
- `SeatViewController.java` — API 설명 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 주요 변경사항

* **기능 개선**
  * 좌석 시야 생성 시 저널 연결이 이제 선택사항입니다. 저널과의 연결 없이도 좌석 시야를 독립적으로 등록할 수 있으므로, 더 유연하고 편리한 좌석 시야 관리가 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->