### PR TITLE
fix : 이미지 S3 key 중복 저장 버그 수정 #144

### DIFF
--- a/src/main/java/com/inninglog/inninglog/domain/contentImage/service/SeatViewImageCreateService.java
+++ b/src/main/java/com/inninglog/inninglog/domain/contentImage/service/SeatViewImageCreateService.java
@@ -29,8 +29,7 @@ public class SeatViewImageCreateService {
                 continue;
             }
 
-            String key = "seatView/" + memberId + "/" + fileName;
-            String originalUrl = s3UrlProperties.getBaseUrl() + "/" + key;
+            String originalUrl = s3UrlProperties.getBaseUrl() + "/" + fileName;
 
             ContentImage contentImage = ContentImage.builder()
                     .contentType(ContentType.SEATVIEW)

--- a/src/main/java/com/inninglog/inninglog/domain/journal/domain/Journal.java
+++ b/src/main/java/com/inninglog/inninglog/domain/journal/domain/Journal.java
@@ -130,7 +130,7 @@ public class Journal extends BaseTimeEntity implements CommentableContent, Likea
 
         String filename = null;
         if (dto.getFileName() != null && !dto.getFileName().trim().isEmpty()) {
-            filename = "journal/" + member.getId() + "/" + dto.getFileName();
+            filename = dto.getFileName();
         }
 
         return Journal.builder()

--- a/src/main/java/com/inninglog/inninglog/domain/journal/dto/req/JourCreateReqDto.java
+++ b/src/main/java/com/inninglog/inninglog/domain/journal/dto/req/JourCreateReqDto.java
@@ -30,7 +30,7 @@ public class JourCreateReqDto {
     @Schema(description = "상대팀 점수", example = "1")
     private int theirScore;
 
-    @Schema(description = "업로드할 이미지 파일명 (확장자 포함)", example = "photo123.jpeg")
+    @Schema(description = "업로드할 이미지 S3 key (Presigned URL 발급 응답의 key 값)", example = "journal/1/photo123.jpeg")
     private String fileName;
 
     @Schema(description = "감정 태그 (감동/짜릿함/답답함/아쉬움/분노 중 하나)", example = "감동")

--- a/src/main/java/com/inninglog/inninglog/domain/seatView/dto/req/SeatCreateReqDto.java
+++ b/src/main/java/com/inninglog/inninglog/domain/seatView/dto/req/SeatCreateReqDto.java
@@ -30,6 +30,6 @@ public class SeatCreateReqDto {
     @Schema(description = "감정 태그 코드 리스트", example = "[    \"CHEERING_MOSTLY_STANDING\", \"SUN_NONE\"]")
     private List<String> emotionTagCodes;
 
-    @Schema(description = "업로드할 이미지 파일명 리스트 (최대 5장, 확장자 포함)", example = "[\"photo1.jpeg\", \"photo2.jpeg\"]")
+    @Schema(description = "업로드할 이미지 S3 key 리스트 (Presigned URL 발급 응답의 key 값, 최대 5장)", example = "[\"seatView/1/photo1.jpeg\", \"seatView/1/photo2.jpeg\"]")
     private List<String> fileNames;
 }


### PR DESCRIPTION
Closes #144

## 원인
배치 Presigned URL API(`POST /images/upload/seatView`, `/journal`) 응답의 `key`가 이미 `seatView/2/seat_xxx.png` 형태인데,
생성 API에서 또 `seatView/{memberId}/` prefix를 붙여 경로가 중복됨

## 수정 파일
- `SeatViewImageCreateService.java` — `"seatView/" + memberId + "/"` prefix 제거, key 직접 사용
- `Journal.from()` — `"journal/" + memberId + "/"` prefix 제거, key 직접 사용
- `JourCreateReqDto.java`, `SeatCreateReqDto.java` — Swagger 설명 S3 key 기준으로 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 이미지 URL 생성 방식을 변경하여 직접 S3 기본 URL에서 파일명을 사용하도록 개선했습니다.

* **Documentation**
  * API 요청 문서를 업데이트하여 S3 presigned URL 응답에서 반환된 키 값을 명확히 명시했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->